### PR TITLE
Create context providers to store and update state

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "web-vitals": "^1.1.1"
       },
       "devDependencies": {
+        "@testing-library/react-hooks": "^5.1.2",
         "@types/react-router-dom": "^5.1.7",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
@@ -2688,6 +2689,42 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz",
+      "integrity": "sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "filter-console": "^0.1.1",
+        "react-error-boundary": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-hooks/node_modules/@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "node_modules/@testing-library/react/node_modules/@babel/runtime": {
       "version": "7.13.17",
       "license": "MIT",
@@ -2900,6 +2937,15 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -7952,6 +7998,15 @@
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/filter-console": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+      "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15353,6 +15408,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+      "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-error-boundary/node_modules/@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
       "license": "MIT"
@@ -22225,6 +22305,31 @@
         }
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz",
+      "integrity": "sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "filter-console": "^0.1.1",
+        "react-error-boundary": "^3.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@testing-library/user-event": {
       "version": "12.8.3",
       "requires": {
@@ -22397,6 +22502,15 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/resolve": {
@@ -25798,6 +25912,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-console": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+      "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+      "dev": true
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -30671,6 +30791,26 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
           "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
           "dev": true
+        }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+      "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/react-hooks": "^5.1.2",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/frontend/src/ContextProviders/PlayersContextProvider.tsx
+++ b/frontend/src/ContextProviders/PlayersContextProvider.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+
+export type Player = {
+  nickname: string;
+  score: number;
+};
+
+type Context = {
+  players: Player[];
+  initialisePlayers?: (arg0: Player[]) => void;
+  addPlayer?: (arg0: string) => void;
+  removePlayer?: (arg0: string) => void;
+  incrementPlayerScore?: (arg0: string) => void;
+};
+
+const PlayersContext = React.createContext<Context>({
+  players: [],
+});
+
+const PlayersContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [players, setPlayers] = useState<Player[]>([]);
+
+  const initialisePlayers = (initialPlayers: Player[]) =>
+    setPlayers(initialPlayers);
+
+  const addPlayer = (nickname: string) =>
+    setPlayers([
+      ...players,
+      {
+        nickname,
+        score: 0,
+      },
+    ]);
+
+  const removePlayer = (nickname: string) =>
+    setPlayers(players.filter((player) => player.nickname !== nickname));
+
+  const incrementPlayerScore = (nickname: string) =>
+    setPlayers(
+      players.map((player) =>
+        player.nickname === nickname
+          ? {
+              nickname,
+              score: player.score + 1,
+            }
+          : player
+      )
+    );
+
+  // The context value that will be supplied to any descendants of this component.
+  const context = {
+    players,
+    initialisePlayers,
+    addPlayer,
+    removePlayer,
+    incrementPlayerScore,
+  };
+
+  // Wraps the given child components in a Provider for the above context.
+  return (
+    <PlayersContext.Provider value={context}>
+      {children}
+    </PlayersContext.Provider>
+  );
+};
+
+export { PlayersContext, PlayersContextProvider };

--- a/frontend/src/ContextProviders/PlayersContextProvider.tsx
+++ b/frontend/src/ContextProviders/PlayersContextProvider.tsx
@@ -31,7 +31,7 @@ const PlayersContextProvider = ({
     addItem,
     removeItem,
     updateItem,
-  } = useCrud<Player>({ equals });
+  } = useCrud<Player>(equals);
 
   const addPlayer = (nickname: string) =>
     addItem({

--- a/frontend/src/ContextProviders/PlayersContextProvider.tsx
+++ b/frontend/src/ContextProviders/PlayersContextProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
+import useCrud from "../hooks/useCrud";
 
 export type Player = {
   nickname: string;
@@ -22,34 +23,50 @@ const PlayersContextProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [players, setPlayers] = useState<Player[]>([]);
-
-  const initialisePlayers = (initialPlayers: Player[]) =>
-    setPlayers(initialPlayers);
+  const {
+    items: players,
+    initialiseItems: initialisePlayers,
+    addItem,
+    removeItem,
+    updateItem,
+  } = useCrud<Player>();
 
   const addPlayer = (nickname: string) =>
-    setPlayers([
-      ...players,
-      {
-        nickname,
-        score: 0,
-      },
-    ]);
+    addItem({
+      nickname,
+      score: 0,
+    });
 
-  const removePlayer = (nickname: string) =>
-    setPlayers(players.filter((player) => player.nickname !== nickname));
+  const equals = (player1: Player, player2: Player) =>
+    player1.nickname === player2.nickname;
 
-  const incrementPlayerScore = (nickname: string) =>
-    setPlayers(
-      players.map((player) =>
-        player.nickname === nickname
-          ? {
-              nickname,
-              score: player.score + 1,
-            }
-          : player
-      )
+  const removePlayer = (nickname: string) => {
+    const playerToRemove = players.find(
+      (player) => player.nickname === nickname
     );
+    if (!playerToRemove) {
+      return;
+    }
+
+    removeItem(playerToRemove, equals);
+  };
+
+  const incrementPlayerScore = (nickname: string) => {
+    const playerToUpdate = players.find(
+      (player) => player.nickname === nickname
+    );
+    if (!playerToUpdate) {
+      return;
+    }
+
+    updateItem(
+      {
+        ...playerToUpdate,
+        score: playerToUpdate.score + 1,
+      },
+      equals
+    );
+  };
 
   // The context value that will be supplied to any descendants of this component.
   const context = {

--- a/frontend/src/ContextProviders/PlayersContextProvider.tsx
+++ b/frontend/src/ContextProviders/PlayersContextProvider.tsx
@@ -5,6 +5,8 @@ export type Player = {
   nickname: string;
   score: number;
 };
+const equals = (player1: Player, player2: Player) =>
+  player1.nickname === player2.nickname;
 
 type Context = {
   players: Player[];
@@ -29,16 +31,13 @@ const PlayersContextProvider = ({
     addItem,
     removeItem,
     updateItem,
-  } = useCrud<Player>();
+  } = useCrud<Player>({ equals });
 
   const addPlayer = (nickname: string) =>
     addItem({
       nickname,
       score: 0,
     });
-
-  const equals = (player1: Player, player2: Player) =>
-    player1.nickname === player2.nickname;
 
   const removePlayer = (nickname: string) => {
     const playerToRemove = players.find(
@@ -48,7 +47,7 @@ const PlayersContextProvider = ({
       return;
     }
 
-    removeItem(playerToRemove, equals);
+    removeItem(playerToRemove);
   };
 
   const incrementPlayerScore = (nickname: string) => {
@@ -59,13 +58,10 @@ const PlayersContextProvider = ({
       return;
     }
 
-    updateItem(
-      {
-        ...playerToUpdate,
-        score: playerToUpdate.score + 1,
-      },
-      equals
-    );
+    updateItem({
+      ...playerToUpdate,
+      score: playerToUpdate.score + 1,
+    });
   };
 
   // The context value that will be supplied to any descendants of this component.

--- a/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
+++ b/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
@@ -26,7 +26,7 @@ const PunchlinesContextProvider = ({
     initialiseItems: initialisePunchlines,
     addItem: addPunchline,
     removeItem,
-  } = useCrud<Punchline>({ equals });
+  } = useCrud<Punchline>(equals);
 
   const removePunchline = (punchline: string) => {
     const punchlineToRemove = punchlines.find(

--- a/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
+++ b/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+
+export type Punchline = string;
+
+type Context = {
+  punchlines: Punchline[];
+  initialisePunchlines?: (arg0: Punchline[]) => void;
+  addPunchline?: (arg0: string) => void;
+  removePunchline?: (arg0: string) => void;
+};
+
+const PunchlinesContext = React.createContext<Context>({
+  punchlines: [],
+});
+
+const PunchlinesContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [punchlines, setPunchlines] = useState<Punchline[]>([]);
+
+  const initialisePunchlines = (initialPunchlines: Punchline[]) =>
+    setPunchlines(initialPunchlines);
+
+  const addPunchline = (punchline: string) =>
+    setPunchlines([...punchlines, punchline]);
+
+  const removePunchline = (punchlineToRemove: string) =>
+    setPunchlines(
+      punchlines.filter((punchline) => punchline !== punchlineToRemove)
+    );
+
+  // The context value that will be supplied to any descendants of this component.
+  const context = {
+    punchlines,
+    initialisePunchlines,
+    addPunchline,
+    removePunchline,
+  };
+
+  // Wraps the given child components in a Provider for the above context.
+  return (
+    <PunchlinesContext.Provider value={context}>
+      {children}
+    </PunchlinesContext.Provider>
+  );
+};
+
+export { PunchlinesContext, PunchlinesContextProvider };

--- a/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
+++ b/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import useCrud from "../hooks/useCrud";
 
 export type Punchline = string;
+const equals = (punchline1: Punchline, punchline2: Punchline) =>
+  punchline1 === punchline2;
 
 type Context = {
   punchlines: Punchline[];
@@ -24,7 +26,7 @@ const PunchlinesContextProvider = ({
     initialiseItems: initialisePunchlines,
     addItem: addPunchline,
     removeItem,
-  } = useCrud<Punchline>();
+  } = useCrud<Punchline>({ equals });
 
   const removePunchline = (punchline: string) => {
     const punchlineToRemove = punchlines.find(
@@ -34,10 +36,7 @@ const PunchlinesContextProvider = ({
       return;
     }
 
-    const equals = (punchline1: Punchline, punchline2: Punchline) =>
-      punchline1 === punchline2;
-
-    removeItem(punchlineToRemove, equals);
+    removeItem(punchlineToRemove);
   };
 
   const context = {

--- a/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
+++ b/frontend/src/ContextProviders/PunchlinesContextProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
+import useCrud from "../hooks/useCrud";
 
 export type Punchline = string;
 
@@ -18,20 +19,27 @@ const PunchlinesContextProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [punchlines, setPunchlines] = useState<Punchline[]>([]);
+  const {
+    items: punchlines,
+    initialiseItems: initialisePunchlines,
+    addItem: addPunchline,
+    removeItem,
+  } = useCrud<Punchline>();
 
-  const initialisePunchlines = (initialPunchlines: Punchline[]) =>
-    setPunchlines(initialPunchlines);
-
-  const addPunchline = (punchline: string) =>
-    setPunchlines([...punchlines, punchline]);
-
-  const removePunchline = (punchlineToRemove: string) =>
-    setPunchlines(
-      punchlines.filter((punchline) => punchline !== punchlineToRemove)
+  const removePunchline = (punchline: string) => {
+    const punchlineToRemove = punchlines.find(
+      (p: Punchline) => p === punchline
     );
+    if (!punchlineToRemove) {
+      return;
+    }
 
-  // The context value that will be supplied to any descendants of this component.
+    const equals = (punchline1: Punchline, punchline2: Punchline) =>
+      punchline1 === punchline2;
+
+    removeItem(punchlineToRemove, equals);
+  };
+
   const context = {
     punchlines,
     initialisePunchlines,
@@ -39,7 +47,6 @@ const PunchlinesContextProvider = ({
     removePunchline,
   };
 
-  // Wraps the given child components in a Provider for the above context.
   return (
     <PunchlinesContext.Provider value={context}>
       {children}

--- a/frontend/src/ContextProviders/index.tsx
+++ b/frontend/src/ContextProviders/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { PlayersContextProvider } from "./PlayersContextProvider";
+
+const ContextProviders = ({ children }: { children: React.ReactNode }) => (
+  <PlayersContextProvider>{children}</PlayersContextProvider>
+);
+
+export default ContextProviders;

--- a/frontend/src/ContextProviders/index.tsx
+++ b/frontend/src/ContextProviders/index.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { PlayersContextProvider } from "./PlayersContextProvider";
+import { PunchlinesContextProvider } from "./PunchlinesContextProvider";
 
 const ContextProviders = ({ children }: { children: React.ReactNode }) => (
-  <PlayersContextProvider>{children}</PlayersContextProvider>
+  <PlayersContextProvider>
+    <PunchlinesContextProvider>{children}</PunchlinesContextProvider>
+  </PlayersContextProvider>
 );
 
 export default ContextProviders;

--- a/frontend/src/hooks/__tests__/useCrud.test.tsx
+++ b/frontend/src/hooks/__tests__/useCrud.test.tsx
@@ -9,7 +9,7 @@ const equals = (item1: TestItem, item2: TestItem) => item1.name === item2.name;
 
 let result: RenderResult<CrudHookType<TestItem>>;
 beforeEach(() => {
-  result = renderHook(() => useCrud<TestItem>({ equals })).result;
+  result = renderHook(() => useCrud<TestItem>(equals)).result;
 });
 
 test("initialiseItems() should update items with initial items", () => {
@@ -49,7 +49,7 @@ test("removeItem() should remove item", () => {
   act(() => result.current.addItem(newItem));
   expect(result.current.items).toEqual([newItem]);
 
-  act(() => result.current.removeItem(newItem, equals));
+  act(() => result.current.removeItem(newItem));
   expect(result.current.items).toEqual([]);
 });
 
@@ -68,6 +68,6 @@ test("updateItem() should update item with new string", () => {
     ...newItem,
     val: 1,
   };
-  act(() => result.current.updateItem(updatedItem, equals));
+  act(() => result.current.updateItem(updatedItem));
   expect(result.current.items).toEqual([updatedItem]);
 });

--- a/frontend/src/hooks/__tests__/useCrud.test.tsx
+++ b/frontend/src/hooks/__tests__/useCrud.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook, RenderResult } from "@testing-library/react-hooks";
+import useCrud, { CrudHookType } from "../useCrud";
+
+type TestItem = {
+  name: string;
+  val: number;
+};
+const equals = (item1: TestItem, item2: TestItem) => item1.name === item2.name;
+
+let result: RenderResult<CrudHookType<TestItem>>;
+beforeEach(() => {
+  result = renderHook(() => useCrud<TestItem>()).result;
+});
+
+test("initialiseItems() should update items with initial items", () => {
+  const initialItems = [
+    {
+      name: "test1",
+      val: 0,
+    },
+    {
+      name: "test2",
+      val: 1,
+    },
+  ];
+  act(() => result.current.initialiseItems(initialItems));
+
+  expect(result.current.items).toEqual(initialItems);
+});
+
+test("addItem() should update items with new item", () => {
+  const newItem = {
+    name: "test1",
+    val: 0,
+  };
+  act(() => result.current.addItem(newItem));
+
+  expect(result.current.items).toEqual([newItem]);
+});
+
+test("removeItem() should remove item", () => {
+  // addItem() has also been unit tested separately above,
+  // so if there is an error here but not in that test
+  // then it must be an error in removeItem()
+  const newItem = {
+    name: "test1",
+    val: 0,
+  };
+  act(() => result.current.addItem(newItem));
+  expect(result.current.items).toEqual([newItem]);
+
+  act(() => result.current.removeItem(newItem, equals));
+  expect(result.current.items).toEqual([]);
+});
+
+test("updateItem() should update item with new string", () => {
+  // addItem() has also been unit tested separately above,
+  // so if there is an error here but not in that test
+  // then it must be an error in updateItem()
+  const newItem = {
+    name: "test1",
+    val: 0,
+  };
+  act(() => result.current.addItem(newItem));
+  expect(result.current.items).toEqual([newItem]);
+
+  const updatedItem = {
+    ...newItem,
+    val: 1,
+  };
+  act(() => result.current.updateItem(updatedItem, equals));
+  expect(result.current.items).toEqual([updatedItem]);
+});

--- a/frontend/src/hooks/__tests__/useCrud.test.tsx
+++ b/frontend/src/hooks/__tests__/useCrud.test.tsx
@@ -9,7 +9,7 @@ const equals = (item1: TestItem, item2: TestItem) => item1.name === item2.name;
 
 let result: RenderResult<CrudHookType<TestItem>>;
 beforeEach(() => {
-  result = renderHook(() => useCrud<TestItem>()).result;
+  result = renderHook(() => useCrud<TestItem>({ equals })).result;
 });
 
 test("initialiseItems() should update items with initial items", () => {

--- a/frontend/src/hooks/useCrud.ts
+++ b/frontend/src/hooks/useCrud.ts
@@ -1,6 +1,21 @@
 import { useState } from "react";
 
-function useCrud<Type>(initialState: Type[] = []) {
+export type CrudHookType<Type> = {
+  items: Type[];
+  initialiseItems: (initialItems: Type[]) => void;
+  addItem: (item: Type) => void;
+  removeItem: (
+    itemToRemove: Type,
+    equals: (item1: Type, item2: Type) => boolean
+  ) => void;
+  updateItem: (
+    updatedItem: Type,
+    equals: (item1: Type, item2: Type) => boolean
+  ) => void;
+};
+
+// Can't use const format since generic Type is only available for functions
+export default function useCrud<Type>(initialState: Type[] = []) {
   const [items, setItems] = useState<Type[]>(initialState);
 
   const initialiseItems = (initialItems: Type[]) => {
@@ -24,7 +39,7 @@ function useCrud<Type>(initialState: Type[] = []) {
       items.map((item) =>
         equals(item, updatedItem)
           ? {
-              item,
+              ...item,
               ...updatedItem,
             }
           : item
@@ -40,4 +55,4 @@ function useCrud<Type>(initialState: Type[] = []) {
   };
 }
 
-export default useCrud;
+// export default useCrud;

--- a/frontend/src/hooks/useCrud.ts
+++ b/frontend/src/hooks/useCrud.ts
@@ -4,25 +4,14 @@ export type CrudHookType<Type> = {
   items: Type[];
   initialiseItems: (initialItems: Type[]) => void;
   addItem: (item: Type) => void;
-  removeItem: (
-    itemToRemove: Type,
-    equals: (item1: Type, item2: Type) => boolean
-  ) => void;
-  updateItem: (
-    updatedItem: Type,
-    equals: (item1: Type, item2: Type) => boolean
-  ) => void;
+  removeItem: (itemToRemove: Type) => void;
+  updateItem: (updatedItem: Type) => void;
 };
 
-type Props<Type> = {
-  initialState?: Type[];
-  equals?: (item1: Type, item2: Type) => boolean;
-};
-
-const useCrud = <Type>({
-  initialState = [],
-  equals = () => false,
-}: Props<Type>) => {
+const useCrud = <Type>(
+  equals: (item1: Type, item2: Type) => boolean,
+  initialState: Type[] = []
+) => {
   const [items, setItems] = useState<Type[]>(initialState);
 
   const initialiseItems = (initialItems: Type[]) => {

--- a/frontend/src/hooks/useCrud.ts
+++ b/frontend/src/hooks/useCrud.ts
@@ -54,5 +54,3 @@ export default function useCrud<Type>(initialState: Type[] = []) {
     updateItem,
   };
 }
-
-// export default useCrud;

--- a/frontend/src/hooks/useCrud.ts
+++ b/frontend/src/hooks/useCrud.ts
@@ -14,8 +14,15 @@ export type CrudHookType<Type> = {
   ) => void;
 };
 
-// Can't use const format since generic Type is only available for functions
-export default function useCrud<Type>(initialState: Type[] = []) {
+type Props<Type> = {
+  initialState?: Type[];
+  equals?: (item1: Type, item2: Type) => boolean;
+};
+
+const useCrud = <Type>({
+  initialState = [],
+  equals = () => false,
+}: Props<Type>) => {
   const [items, setItems] = useState<Type[]>(initialState);
 
   const initialiseItems = (initialItems: Type[]) => {
@@ -26,15 +33,10 @@ export default function useCrud<Type>(initialState: Type[] = []) {
 
   const addItem = (item: Type) => setItems([...items, item]);
 
-  const removeItem = (
-    itemToRemove: Type,
-    equals: (item1: Type, item2: Type) => boolean
-  ) => setItems(items.filter((item) => !equals(item, itemToRemove)));
+  const removeItem = (itemToRemove: Type) =>
+    setItems(items.filter((item) => !equals(item, itemToRemove)));
 
-  const updateItem = (
-    updatedItem: Type,
-    equals: (item1: Type, item2: Type) => boolean
-  ) =>
+  const updateItem = (updatedItem: Type) =>
     setItems(
       items.map((item) =>
         equals(item, updatedItem)
@@ -53,4 +55,6 @@ export default function useCrud<Type>(initialState: Type[] = []) {
     removeItem,
     updateItem,
   };
-}
+};
+
+export default useCrud;

--- a/frontend/src/hooks/useCrud.tsx
+++ b/frontend/src/hooks/useCrud.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+function useCrud<Type>(initialState: Type[] = []) {
+  const [items, setItems] = useState<Type[]>(initialState);
+
+  const initialiseItems = (initialItems: Type[]) => {
+    if (items.length === 0) {
+      setItems(initialItems);
+    }
+  };
+
+  const addItem = (item: Type) => setItems([...items, item]);
+
+  const removeItem = (
+    itemToRemove: Type,
+    equals: (item1: Type, item2: Type) => boolean
+  ) => setItems(items.filter((item) => !equals(item, itemToRemove)));
+
+  const updateItem = (
+    updatedItem: Type,
+    equals: (item1: Type, item2: Type) => boolean
+  ) =>
+    setItems(
+      items.map((item) =>
+        equals(item, updatedItem)
+          ? {
+              item,
+              ...updatedItem,
+            }
+          : item
+      )
+    );
+
+  return {
+    items,
+    initialiseItems,
+    addItem,
+    removeItem,
+    updateItem,
+  };
+}
+
+export default useCrud;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import ContextProviders from "./ContextProviders";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ContextProviders>
+      <App />
+    </ContextProviders>
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
Closes #35 
- Created PlayersContextProvider to store and update list of players, each with a nickname and score
- Created PunchlinesContextProvider to store and update list of punchlines
- Created base ContextProviders provider to encapsulate all context providers
- Created custom useCrud hook to store and update items e.g. players or punchlines, with unit tests for updating state