### PR TITLE
Socket bugs

### DIFF
--- a/backend/src/handlers/__tests__/auth.handler.test.ts
+++ b/backend/src/handlers/__tests__/auth.handler.test.ts
@@ -35,7 +35,7 @@ describe("auth Handler", () => {
     expect(socket.data).toMatchObject(socket.handshake.auth);
   });
 
-  it("calls next() with an error with invalid credentials", async () => {
+  it("calls next() with an error if validatePlayerId returns false", async () => {
     spy.mockReturnValue(false);
 
     const next = jest.fn();
@@ -44,5 +44,16 @@ describe("auth Handler", () => {
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(new Error("Invalid player credentials"));
+  });
+
+  it("calls next() with an error if validatePlayerId throws an error", async () => {
+    spy.mockRejectedValue(Error());
+
+    const next = jest.fn();
+
+    await Auth(socket, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(Error("Invalid player credentials"));
   });
 });

--- a/backend/src/handlers/__tests__/player.handler.test.ts
+++ b/backend/src/handlers/__tests__/player.handler.test.ts
@@ -104,8 +104,8 @@ describe("playerJoin handler", () => {
 
     expect(emitMock).toHaveBeenCalledTimes(2);
     expect(emitMock).toHaveBeenCalledWith("players:initial", [
-      { nickname: "Bob", score: 0, new: false },
-      { nickname: "James", score: 1, new: false },
+      { nickname: "Bob", score: 0 },
+      { nickname: "James", score: 1 },
     ]);
     expect(emitMock).toHaveBeenCalledWith("settings:initial", "{SETTINGS}");
 

--- a/backend/src/handlers/__tests__/player.handler.test.ts
+++ b/backend/src/handlers/__tests__/player.handler.test.ts
@@ -63,7 +63,10 @@ describe("playerJoin handler", () => {
         { nickname: "Fred", score: 0, new: true },
         { nickname: "James", score: 1, new: false },
       ],
-      settings: "{SETTINGS}",
+      settings: {
+        roundLimit: 69,
+        maxPlayers: 25,
+      },
     } as unknown) as Game;
 
     getGameSpy = jest
@@ -108,7 +111,10 @@ describe("playerJoin handler", () => {
       { nickname: "Bob", score: 0 },
       { nickname: "James", score: 1 },
     ]);
-    expect(emitMock).toHaveBeenCalledWith("settings:initial", "{SETTINGS}");
+    expect(emitMock).toHaveBeenCalledWith("settings:initial", {
+      roundLimit: 69,
+      maxPlayers: 25,
+    });
 
     expect(emitNavigateSpy).toHaveBeenCalledTimes(1);
     expect(emitNavigateSpy).toHaveBeenCalledWith(socket, game);

--- a/backend/src/handlers/__tests__/player.handler.test.ts
+++ b/backend/src/handlers/__tests__/player.handler.test.ts
@@ -4,6 +4,7 @@ import * as PlayerService from "../../services/player.service";
 import * as GameHandler from "../game.handler";
 import registerPlayerHandler, { playerJoin } from "../player.handler";
 import { Game, GameState, Player } from "../../models";
+import { ErrorType, ServiceError } from "../../util";
 
 describe("playerJoin handler", () => {
   let getGameSpy: jest.SpyInstance;
@@ -210,6 +211,66 @@ describe("playerJoin handler", () => {
 
     expect(socket.data.nickname).toBe("Bob");
   });
+
+  it("catches error thrown by getGame and disconnects player", async () => {
+    const player: Player = ({
+      nickname: "Bob",
+      new: true,
+    } as unknown) as Player;
+    getPlayerSpy.mockReturnValue(player);
+
+    fetchMock.mockReturnValue(["1"]);
+
+    getGameSpy.mockRejectedValue(
+      new ServiceError(ErrorType.gameCode, "Game does not exist")
+    );
+    socket.disconnect = jest.fn();
+
+    await playerJoin(io, socket);
+
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it("catches error thrown by getPlayer and disconnects player", async () => {
+    const player: Player = ({
+      nickname: "Bob",
+      new: true,
+    } as unknown) as Player;
+    getPlayerSpy.mockReturnValue(player);
+
+    fetchMock.mockReturnValue(["1"]);
+
+    getPlayerSpy.mockRejectedValue(
+      new ServiceError(ErrorType.playerName, "Player does not exist")
+    );
+    socket.disconnect = jest.fn();
+
+    await playerJoin(io, socket);
+
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it("catches error thrown by initialisePlayer and disconnects player", async () => {
+    const player: Player = ({
+      nickname: "Bob",
+      new: true,
+    } as unknown) as Player;
+    getPlayerSpy.mockReturnValue(player);
+
+    fetchMock.mockReturnValue(["1"]);
+
+    initialisePlayerSpy.mockRejectedValue(
+      new ServiceError(ErrorType.playerName, "Player does not exist")
+    );
+    socket.disconnect = jest.fn();
+
+    await playerJoin(io, socket);
+
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
 });
 
 describe("Player handlers", () => {
@@ -317,6 +378,36 @@ describe("Player handlers", () => {
       expect(toMock).toHaveBeenCalledTimes(0);
 
       expect(emitMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("catches error thrown by getGame", async () => {
+      gameSpy.mockRejectedValue(
+        new ServiceError(ErrorType.gameCode, "Game does not exist")
+      );
+
+      removeSpy.mockReturnValue({
+        nickname: "Bob",
+      });
+
+      await handlers.playerLeave();
+
+      expect(gameSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("catches error thrown by removePlayer", async () => {
+      const game = ({
+        gameCode: "42069",
+        state: GameState.lobby,
+      } as unknown) as Game;
+      gameSpy.mockReturnValue(game);
+
+      removeSpy.mockRejectedValue(
+        new ServiceError(ErrorType.playerName, "Player does not exist")
+      );
+
+      await handlers.playerLeave();
+
+      expect(removeSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -514,6 +605,26 @@ describe("Player handlers", () => {
       await handlers.playerLeaving();
 
       expect(setHostSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("catches error thrown by getGame", async () => {
+      const socket = ({
+        data: {
+          gameCode: "42069",
+          playerId: "1",
+        },
+        on: jest.fn(),
+      } as unknown) as Socket;
+
+      fetchMock.mockReturnValue([{ data: { playerId: "1" } }]);
+
+      handlers = await registerPlayerHandler(io, socket);
+
+      isHostSpy.mockReturnValue(true);
+
+      await handlers.playerLeaving();
+
+      expect(gameSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/src/handlers/__tests__/player.handler.test.ts
+++ b/backend/src/handlers/__tests__/player.handler.test.ts
@@ -464,6 +464,33 @@ describe("Player handlers", () => {
       });
     });
 
+    it("assigns new host skipping non-active players", async () => {
+      const socket = ({
+        data: {
+          gameCode: "42069",
+          playerId: "1",
+          nickname: "Steve",
+        },
+        on: jest.fn(),
+      } as unknown) as Socket;
+
+      fetchMock.mockReturnValue([
+        { data: { playerId: "1" } },
+        { data: { playerId: "3", nickname: "Dave" } },
+      ]);
+
+      handlers = await registerPlayerHandler(io, socket);
+
+      isHostSpy.mockReturnValue(true);
+
+      await handlers.playerLeaving();
+
+      expect(setHostSpy).toHaveBeenCalledTimes(1);
+      expect(setHostSpy).toHaveBeenCalledWith(io, {
+        data: { playerId: "3", nickname: "Dave" },
+      });
+    });
+
     it("does not set host if new host socket is somehow undefined", async () => {
       const socket = ({
         data: {

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -10,8 +10,13 @@ export default async (
   socket.data.gameCode = gameCode;
   socket.data.playerId = playerId;
 
-  if (await validatePlayerId(gameCode, playerId)) {
-    return next();
+  const error = new Error("Invalid player credentials");
+  try {
+    if (await validatePlayerId(gameCode, playerId)) {
+      return next();
+    }
+  } catch {
+    return next(error);
   }
-  next(new Error("Invalid player credentials"));
+  next(error);
 };

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -35,7 +35,7 @@ export default (
             await setRoundLimitService(game, value);
             break;
         }
-        socket.emit("settings:update", setting, value);
+        socket.to(gameCode).emit("settings:update", setting, value);
       }
     } catch (e) {
       if (e instanceof ServiceError) {

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -5,6 +5,7 @@ import {
   setMaxPlayers as setMaxPlayersService,
   setRoundLimit as setRoundLimitService,
 } from "../services/game.service";
+import { ServiceError } from "../util";
 
 export default (
   io: Server,
@@ -12,26 +13,36 @@ export default (
 ): {
   updateSetting: (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined
+    value: number | undefined,
+    callback: (data: string) => void
   ) => Promise<void>;
 } => {
   const { gameCode } = socket.data;
 
   const updateSetting = async (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined
+    value: number | undefined,
+    callback: (data: string) => void
   ): Promise<void> => {
-    if (isHost(socket, gameCode)) {
-      const game = await getGame(gameCode);
-      switch (setting) {
-        case "MAX_PLAYERS":
-          await setMaxPlayersService(game, value);
-          break;
-        case "ROUND_LIMIT":
-          await setRoundLimitService(game, value);
-          break;
+    try {
+      if (isHost(socket, gameCode)) {
+        const game = await getGame(gameCode);
+        switch (setting) {
+          case "MAX_PLAYERS":
+            await setMaxPlayersService(game, value);
+            break;
+          case "ROUND_LIMIT":
+            await setRoundLimitService(game, value);
+            break;
+        }
+        socket.emit("settings:update", setting, value);
       }
-      socket.emit("settings:update", setting, value);
+    } catch (e) {
+      if (e instanceof ServiceError) {
+        callback(e.message);
+      } else {
+        callback("Server error");
+      }
     }
   };
 

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -101,7 +101,10 @@ export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
           };
         })
     );
-    socket.emit("settings:initial", game.settings);
+    socket.emit("settings:initial", {
+      roundLimit: game.settings.roundLimit,
+      maxPlayers: game.settings.maxPlayers,
+    });
     emitNavigate(socket, game);
 
     const sockets = await io.in(gameCode).fetchSockets();

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -70,19 +70,19 @@ export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
 
   const game = await getGame(gameCode);
 
-  socket.emit(
-    "players:initial",
-    game.players.filter((v) => !v.new)
-  );
-  socket.emit("settings:initial", game.settings);
-  emitNavigate(socket, game);
-
   const player = await getPlayer(game.gameCode, playerId, game);
   if (player.new) {
     await initialisePlayer(game, playerId);
     socket.to(game.gameCode).emit("players:add", player.nickname);
   }
   socket.data.nickname = player.nickname;
+
+  socket.emit(
+    "players:initial",
+    game.players.filter((v) => !v.new)
+  );
+  socket.emit("settings:initial", game.settings);
+  emitNavigate(socket, game);
 
   const sockets = await io.in(gameCode).fetchSockets();
   await socket.join(game.gameCode);

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -79,7 +79,14 @@ export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
 
   socket.emit(
     "players:initial",
-    game.players.filter((v) => !v.new)
+    game.players
+      .filter((player) => !player.new)
+      .map((player) => {
+        return {
+          nickname: player.nickname,
+          score: player.score,
+        };
+      })
   );
   socket.emit("settings:initial", game.settings);
   emitNavigate(socket, game);

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -19,11 +19,11 @@ export default (
 
   const playerLeaving = async (): Promise<void> => {
     if (isHost(socket, gameCode)) {
-      const game = await getGame(gameCode);
-
       const sockets = ((await io
         .in(gameCode)
         .fetchSockets()) as unknown) as Socket[];
+
+      const game = await getGame(gameCode);
 
       const playerIdToSocket = new Map<Player["id"], Socket>(
         sockets.map((socket) => [socket.data.playerId, socket])
@@ -39,7 +39,7 @@ export default (
         let nextHostIndex = leavingHostIndex + 1;
         if (nextHostIndex === activePlayers.length) nextHostIndex = 0;
 
-        const newHost = game.players[nextHostIndex];
+        const newHost = activePlayers[nextHostIndex];
         const newHostSocket = playerIdToSocket.get(newHost.id);
 
         if (newHostSocket !== undefined) setHost(io, newHostSocket);

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -18,42 +18,54 @@ export default (
   const { gameCode, playerId } = socket.data;
 
   const playerLeaving = async (): Promise<void> => {
-    if (isHost(socket, gameCode)) {
-      const sockets = ((await io
-        .in(gameCode)
-        .fetchSockets()) as unknown) as Socket[];
+    try {
+      if (isHost(socket, gameCode)) {
+        const sockets = ((await io
+          .in(gameCode)
+          .fetchSockets()) as unknown) as Socket[];
 
-      const game = await getGame(gameCode);
+        const game = await getGame(gameCode);
 
-      const playerIdToSocket = new Map<Player["id"], Socket>(
-        sockets.map((socket) => [socket.data.playerId, socket])
-      );
-      const activePlayers = game.players.filter((player) =>
-        playerIdToSocket.has(player.id)
-      );
-
-      if (activePlayers.length > 1) {
-        const leavingHostIndex = activePlayers.findIndex(
-          (player) => player.id === playerId
+        const playerIdToSocket = new Map<Player["id"], Socket>(
+          sockets.map((socket) => [socket.data.playerId, socket])
         );
-        let nextHostIndex = leavingHostIndex + 1;
-        if (nextHostIndex === activePlayers.length) nextHostIndex = 0;
+        const activePlayers = game.players.filter((player) =>
+          playerIdToSocket.has(player.id)
+        );
 
-        const newHost = activePlayers[nextHostIndex];
-        const newHostSocket = playerIdToSocket.get(newHost.id);
+        if (activePlayers.length > 1) {
+          const leavingHostIndex = activePlayers.findIndex(
+            (player) => player.id === playerId
+          );
+          let nextHostIndex = leavingHostIndex + 1;
+          if (nextHostIndex === activePlayers.length) nextHostIndex = 0;
 
-        if (newHostSocket !== undefined) setHost(io, newHostSocket);
+          const newHost = activePlayers[nextHostIndex];
+          const newHostSocket = playerIdToSocket.get(newHost.id);
+
+          if (newHostSocket !== undefined) setHost(io, newHostSocket);
+        }
       }
-    }
+      /* Empty catch block to keep console clean during testing.
+       * Could use proper logging here such as winston
+       * https://github.com/winstonjs/winston */
+      // eslint-disable-next-line no-empty
+    } catch {}
   };
 
   const playerLeave = async (): Promise<void> => {
-    const game = await getGame(gameCode);
+    try {
+      const game = await getGame(gameCode);
 
-    if (game.state === GameState.lobby) {
-      const player = await removePlayer(game, playerId);
-      socket.to(game.gameCode).emit("players:remove", player.nickname);
-    }
+      if (game.state === GameState.lobby) {
+        const player = await removePlayer(game, playerId);
+        socket.to(game.gameCode).emit("players:remove", player.nickname);
+      }
+      /* Empty catch block to keep console clean during testing.
+       * Could use proper logging here such as winston
+       * https://github.com/winstonjs/winston */
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
   };
 
   socket.on("disconnect", playerLeave);
@@ -66,36 +78,40 @@ export default (
 };
 
 export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
-  const { gameCode, playerId } = socket.data;
+  try {
+    const { gameCode, playerId } = socket.data;
 
-  const game = await getGame(gameCode);
+    const game = await getGame(gameCode);
 
-  const player = await getPlayer(game.gameCode, playerId, game);
-  if (player.new) {
-    await initialisePlayer(game, playerId);
-    socket.to(game.gameCode).emit("players:add", player.nickname);
-  }
-  socket.data.nickname = player.nickname;
+    const player = await getPlayer(game.gameCode, playerId, game);
+    if (player.new) {
+      await initialisePlayer(game, playerId);
+      socket.to(game.gameCode).emit("players:add", player.nickname);
+    }
+    socket.data.nickname = player.nickname;
 
-  socket.emit(
-    "players:initial",
-    game.players
-      .filter((player) => !player.new)
-      .map((player) => {
-        return {
-          nickname: player.nickname,
-          score: player.score,
-        };
-      })
-  );
-  socket.emit("settings:initial", game.settings);
-  emitNavigate(socket, game);
+    socket.emit(
+      "players:initial",
+      game.players
+        .filter((player) => !player.new)
+        .map((player) => {
+          return {
+            nickname: player.nickname,
+            score: player.score,
+          };
+        })
+    );
+    socket.emit("settings:initial", game.settings);
+    emitNavigate(socket, game);
 
-  const sockets = await io.in(gameCode).fetchSockets();
-  await socket.join(game.gameCode);
-  if (sockets.length === 0) {
-    setHost(io, socket);
-  } else {
-    await emitHost(io, socket);
+    const sockets = await io.in(gameCode).fetchSockets();
+    await socket.join(game.gameCode);
+    if (sockets.length === 0) {
+      setHost(io, socket);
+    } else {
+      await emitHost(io, socket);
+    }
+  } catch (e) {
+    socket.disconnect(true);
   }
 };


### PR DESCRIPTION
Address bugs identified in the Socket handlers:

- #61: Event `players:initial` was not returning the current player due to it being called before the player was initialised with its `new` flag set to `false`. `playerJoin()` was refactored to correctly order the sequence of calls.
- #62: Add error handling to `auth.handler.ts` with a corresponding test.
- #63: Remove player IDs being returned by the event `players:initial`.
- Remove setting IDs being returned by the event `settings:intiial`
- #64: Assigning a new host was not being properly processed due to an apparent race condition between Socket.IO and the database as well as improper array indexing.
- Added general error handling to game and player handlers
- #69: Setting updates were not broadcast to all players in a game