### PR TITLE
Player tokens

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.17.1",
         "helmet": "^4.5.0",
         "mongoose": "^5.12.7",
-        "socket.io": "^4.0.1"
+        "socket.io": "^4.0.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@babel/core": "^7.13.16",
@@ -31,6 +32,7 @@
         "@types/jest": "^26.0.23",
         "@types/node": "^14.14.41",
         "@types/socket.io": "^2.1.13",
+        "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
         "babel-jest": "^26.6.3",
@@ -2347,6 +2349,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
       "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -10478,7 +10486,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12745,6 +12752,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
       "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -18952,8 +18965,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,8 @@
     "express": "^4.17.1",
     "helmet": "^4.5.0",
     "mongoose": "^5.12.7",
-    "socket.io": "^4.0.1"
+    "socket.io": "^4.0.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",
@@ -35,6 +36,7 @@
     "@types/jest": "^26.0.23",
     "@types/node": "^14.14.41",
     "@types/socket.io": "^2.1.13",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "babel-jest": "^26.6.3",

--- a/backend/src/controllers/__tests__/player.controller.test.ts
+++ b/backend/src/controllers/__tests__/player.controller.test.ts
@@ -36,7 +36,10 @@ describe("Player controller", () => {
 
     const next: any = jest.fn();
 
-    createSpy.mockReturnValue("69eb420cg69");
+    createSpy.mockReturnValue({
+      playerId: "69eb420cg69",
+      token: "62410075-a9f8-4557-acd5-41c6b8bb039e",
+    });
 
     await createPlayer(req, res, next);
 
@@ -46,7 +49,10 @@ describe("Player controller", () => {
     expect(status).toHaveBeenCalledWith(201);
 
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith("69eb420cg69");
+    expect(send).toHaveBeenCalledWith({
+      playerId: "69eb420cg69",
+      token: "62410075-a9f8-4557-acd5-41c6b8bb039e",
+    });
   });
 
   it("Responds with a 400 if the game code is invalid", async () => {

--- a/backend/src/controllers/player.controller.ts
+++ b/backend/src/controllers/player.controller.ts
@@ -18,8 +18,11 @@ export const createPlayer = async (
       res.status(400).send("Nickname not of type string");
       return;
     }
-    const playerId = await createPlayerService(code, nickname);
-    res.status(201).send(playerId);
+    const { playerId, token } = await createPlayerService(code, nickname);
+    res.status(201).send({
+      playerId: playerId,
+      token: token,
+    });
     return;
   } catch (e) {
     if (e.type === ErrorType.gameCode) {

--- a/backend/src/handlers/__tests__/auth.handler.test.ts
+++ b/backend/src/handlers/__tests__/auth.handler.test.ts
@@ -7,13 +7,17 @@ describe("auth Handler", () => {
 
   const socket = ({
     handshake: {
-      auth: { gameCode: "42069", playerId: "abc123" },
+      auth: {
+        gameCode: "42069",
+        playerId: "abc123",
+        token: "ac99723a-66be-4ecc-ba40-14dcaa73a441",
+      },
     },
     data: {},
   } as unknown) as Socket;
 
   beforeEach(() => {
-    spy = jest.spyOn(PlayerService, "validatePlayerId");
+    spy = jest.spyOn(PlayerService, "authenticatePlayer");
   });
 
   afterEach(() => {
@@ -28,11 +32,18 @@ describe("auth Handler", () => {
     await Auth(socket, next);
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("42069", "abc123");
+    expect(spy).toHaveBeenCalledWith(
+      "42069",
+      "abc123",
+      "ac99723a-66be-4ecc-ba40-14dcaa73a441"
+    );
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith();
 
-    expect(socket.data).toMatchObject(socket.handshake.auth);
+    expect(socket.data).toMatchObject({
+      gameCode: "42069",
+      playerId: "abc123",
+    });
   });
 
   it("calls next() with an error with invalid credentials", async () => {

--- a/backend/src/handlers/__tests__/player.handler.test.ts
+++ b/backend/src/handlers/__tests__/player.handler.test.ts
@@ -58,9 +58,24 @@ describe("playerJoin handler", () => {
     game = ({
       gameCode: "42069",
       players: [
-        { nickname: "Bob", score: 0, new: false },
-        { nickname: "Fred", score: 0, new: true },
-        { nickname: "James", score: 1, new: false },
+        {
+          id: "abc123",
+          nickname: "Bob",
+          score: 0,
+          new: false,
+        },
+        {
+          id: "def456",
+          nickname: "Fred",
+          score: 0,
+          new: true,
+        },
+        {
+          id: "ghi789",
+          nickname: "James",
+          score: 1,
+          new: false,
+        },
       ],
       settings: "{SETTINGS}",
     } as unknown) as Game;
@@ -104,8 +119,16 @@ describe("playerJoin handler", () => {
 
     expect(emitMock).toHaveBeenCalledTimes(2);
     expect(emitMock).toHaveBeenCalledWith("players:initial", [
-      { nickname: "Bob", score: 0, new: false },
-      { nickname: "James", score: 1, new: false },
+      {
+        id: "abc123",
+        nickname: "Bob",
+        score: 0,
+      },
+      {
+        id: "ghi789",
+        nickname: "James",
+        score: 1,
+      },
     ]);
     expect(emitMock).toHaveBeenCalledWith("settings:initial", "{SETTINGS}");
 

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -1,16 +1,16 @@
 import { Socket } from "socket.io";
-import { validatePlayerId } from "../services/player.service";
+import { authenticatePlayer } from "../services/player.service";
 
 export default async (
   socket: Socket,
   next: (err?: Error) => void
 ): Promise<void> => {
-  const { gameCode, playerId } = socket.handshake.auth;
+  const { gameCode, playerId, token } = socket.handshake.auth;
 
   socket.data.gameCode = gameCode;
   socket.data.playerId = playerId;
 
-  if (await validatePlayerId(gameCode, playerId)) {
+  if (await authenticatePlayer(gameCode, playerId, token)) {
     return next();
   }
   next(new Error("Invalid player credentials"));

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -72,7 +72,15 @@ export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
 
   socket.emit(
     "players:initial",
-    game.players.filter((v) => !v.new)
+    game.players
+      .filter((player) => !player.new)
+      .map((player) => {
+        return {
+          id: player.id,
+          nickname: player.nickname,
+          score: player.score,
+        };
+      })
   );
   socket.emit("settings:initial", game.settings);
   emitNavigate(socket, game);

--- a/backend/src/models/__tests__/game.model.test.ts
+++ b/backend/src/models/__tests__/game.model.test.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import { GameModel, GameState, SetupType } from "../../models";
 import { RoundState } from "../round.model";
+import { validate as validateUUID } from "uuid";
 
 describe("Game Model", () => {
   let gameCode = 42069;
@@ -130,7 +131,7 @@ describe("Game Model", () => {
     }
   });
 
-  it("inserts a player with new defaulting to true and score defaulting to zero", async () => {
+  it("inserts a player with new defaulting to true, score defaulting to zero and assigning a random UUID", async () => {
     gameData.players = [
       { nickname: "Bob" },
       { nickname: "Fred" },
@@ -146,6 +147,25 @@ describe("Game Model", () => {
     expect(savedGame.players[2].punchlines).toHaveProperty("length", 0);
     expect([...savedGame.players]).toMatchObject(Array(3).fill({ new: true }));
     expect([...savedGame.players]).toMatchObject(Array(3).fill({ score: 0 }));
+    expect(validateUUID(savedGame.players[0].token)).toBeTruthy();
+    expect(validateUUID(savedGame.players[1].token)).toBeTruthy();
+    expect(validateUUID(savedGame.players[2].token)).toBeTruthy();
+  });
+
+  it("throws a ValidationError if a player is added without a nickname", async () => {
+    gameData.players = [
+      { punchlines: ["To get to the other side"] },
+      { punchlines: ["To go to KFC"] },
+    ];
+
+    const game = new GameModel(gameData);
+
+    try {
+      await game.save();
+    } catch (e) {
+      expect(e).toBeInstanceOf(mongoose.Error.ValidationError);
+      expect(e.errors.players).toBeDefined();
+    }
   });
 
   it("throws a ValidationError if two players with the same nickname are added to the same game", async () => {

--- a/backend/src/models/__tests__/game.model.test.ts
+++ b/backend/src/models/__tests__/game.model.test.ts
@@ -162,6 +162,7 @@ describe("Game Model", () => {
 
     try {
       await game.save();
+      fail("nicknames are required");
     } catch (e) {
       expect(e).toBeInstanceOf(mongoose.Error.ValidationError);
       expect(e.errors.players).toBeDefined();
@@ -175,6 +176,7 @@ describe("Game Model", () => {
 
     try {
       await game.save();
+      fail("unique nicknames are required");
     } catch (e) {
       expect(e).toBeInstanceOf(mongoose.Error.ValidationError);
       expect(e.errors.players).toBeDefined();

--- a/backend/src/models/player.model.ts
+++ b/backend/src/models/player.model.ts
@@ -1,6 +1,8 @@
 import { Document, Schema } from "mongoose";
+import { v4 as uuid } from "uuid";
 
 export interface Player extends Document {
+  token: string;
   nickname: string;
   punchlines: string[];
   score: number;
@@ -8,6 +10,7 @@ export interface Player extends Document {
 }
 
 export const PlayerSchema: Schema = new Schema({
+  token: { type: String, default: () => uuid() },
   nickname: { type: String, required: true },
   punchlines: [String],
   score: { type: Number, default: 0 },

--- a/backend/src/services/__tests__/player.service.test.ts
+++ b/backend/src/services/__tests__/player.service.test.ts
@@ -41,7 +41,7 @@ describe("createPlayer Service", () => {
 
     const player = game.players.id(playerId);
     expect(player).toBeDefined();
-    if (player === null) return;
+    if (player === null) return fail("missing player");
     expect(token).toBe(player.token);
     expect(validateUUID(token)).toBeTruthy();
     expect(mongoose.Types.ObjectId.isValid(playerId));

--- a/backend/src/services/__tests__/player.service.test.ts
+++ b/backend/src/services/__tests__/player.service.test.ts
@@ -44,6 +44,7 @@ describe("createPlayer Service", () => {
     if (player === null) return;
     expect(token).toBe(player.token);
     expect(validateUUID(token)).toBeTruthy();
+    expect(mongoose.Types.ObjectId.isValid(playerId));
   });
 
   it("throws an error when provided an invalid gameCode", async () => {

--- a/backend/src/services/player.service.ts
+++ b/backend/src/services/player.service.ts
@@ -59,13 +59,14 @@ export const getPlayer = async (
   throw new ServiceError(ErrorType.playerName, "Player does not exist");
 };
 
-export const validatePlayerId = async (
+export const authenticatePlayer = async (
   gameCode: Game["gameCode"],
-  playerId: Player["id"]
+  playerId: Player["id"],
+  token: Player["token"]
 ): Promise<boolean> => {
   return await GameModel.exists({
     gameCode: gameCode,
-    players: { $elemMatch: { _id: playerId } },
+    players: { $elemMatch: { _id: playerId, token: token } },
   });
 };
 

--- a/backend/src/services/player.service.ts
+++ b/backend/src/services/player.service.ts
@@ -2,10 +2,15 @@ import { getGame } from "./game.service";
 import { Game, GameModel, Player } from "../models";
 import { ErrorType, ServiceError } from "../util";
 
+type CreatePlayerResponse = {
+  playerId: Player["id"];
+  token: Player["token"];
+};
+
 export const createPlayer = async (
   gameCode: Game["gameCode"],
   nickname: string
-): Promise<Player["id"]> => {
+): Promise<CreatePlayerResponse> => {
   const game = await getGame(gameCode);
 
   const length = game.players.push({
@@ -19,7 +24,10 @@ export const createPlayer = async (
     throw new ServiceError(ErrorType.playerName, "Duplicate player nickname");
   }
 
-  return player.id;
+  return {
+    playerId: player.id,
+    token: player.token,
+  };
 };
 
 export const removePlayer = async (

--- a/frontend/src/api/__tests__/createPlayer.test.ts
+++ b/frontend/src/api/__tests__/createPlayer.test.ts
@@ -1,6 +1,6 @@
 import mockAxios from "jest-mock-axios";
 import { AxiosError, AxiosResponse } from "axios";
-import createPlayer from "../createPlayer";
+import createPlayer, { Response } from "../createPlayer";
 import { BASE_URL } from "../axiosCall";
 
 const testPlayer = {
@@ -13,8 +13,11 @@ afterEach(() => {
 });
 
 test("should return user id on successful creation", async () => {
-  const mockResponse: AxiosResponse<string> = {
-    data: "1a2b3c",
+  const mockResponse: AxiosResponse<Response> = {
+    data: {
+      playerId: "abc123",
+      token: "f7d01fef-cd47-496a-b7eb-5dd26f771721",
+    },
     status: 201,
     statusText: "CREATED",
     headers: {},
@@ -35,7 +38,10 @@ test("should return user id on successful creation", async () => {
   expect(res).toEqual({
     success: true,
     status: 201,
-    data: "1a2b3c",
+    data: {
+      playerId: "abc123",
+      token: "f7d01fef-cd47-496a-b7eb-5dd26f771721",
+    },
   });
 });
 

--- a/frontend/src/api/createPlayer.ts
+++ b/frontend/src/api/createPlayer.ts
@@ -9,6 +9,11 @@ type Props = {
   nickname: string;
 };
 
+export type Response = {
+  playerId: string;
+  token: string;
+};
+
 /**
  * Expected status codes:
  * 201 - Player Created Successfully,
@@ -17,7 +22,7 @@ type Props = {
  * @param gameCode - code of the game the player will be added to
  * @param nickname - nickname of the new player
  */
-const createPlayer: (player: Props) => Promise<ApiResponse<string>> = async ({
+const createPlayer: (player: Props) => Promise<ApiResponse<Response>> = async ({
   gameCode,
   nickname,
 }: Props) => {
@@ -32,7 +37,7 @@ const createPlayer: (player: Props) => Promise<ApiResponse<string>> = async ({
 
   const url = `${BASE_URL}/player/create`;
   const axiosMethod = async () =>
-    axios.post<any, AxiosResponse<string>>(url, undefined, {
+    axios.post<any, AxiosResponse<Response>>(url, undefined, {
       params: {
         gameCode,
         nickname,
@@ -40,7 +45,7 @@ const createPlayer: (player: Props) => Promise<ApiResponse<string>> = async ({
     });
   const acceptedCodes = [CREATED_201];
 
-  return axiosCall<string>({ axiosMethod, acceptedCodes });
+  return axiosCall<Response>({ axiosMethod, acceptedCodes });
 };
 
 export default createPlayer;

--- a/frontend/src/pages/NicknamePage/index.tsx
+++ b/frontend/src/pages/NicknamePage/index.tsx
@@ -9,6 +9,7 @@ import validateGame from "../../api/validateGame";
 import createPlayer from "../../api/createPlayer";
 
 const usePlayerIdState = createPersistedState("playerId");
+const useTokenState = createPersistedState("token");
 
 type Props = {
   gameCode: string;
@@ -18,6 +19,7 @@ const NicknamePage = ({ gameCode }: Props) => {
   const [nickname, setNickname] = useState("");
   const [error, setError] = useState("");
   const [playerId, setPlayerId] = usePlayerIdState("");
+  const [token, setToken] = useTokenState("");
 
   const memoryHistory = useHistory();
   const browserHistory = useContext(BrowserHistoryContext);
@@ -28,7 +30,7 @@ const NicknamePage = ({ gameCode }: Props) => {
 
       const gameCodeIsValid = res.success;
       if (gameCodeIsValid) {
-        if (playerId) {
+        if (playerId && token) {
           // TODO try connect to socket.io
           // No way to check whether playerId is for the current gameCode
         } else {
@@ -45,7 +47,8 @@ const NicknamePage = ({ gameCode }: Props) => {
 
     if (res.success) {
       if (res.data) {
-        setPlayerId(res.data);
+        setPlayerId(res.data.playerId);
+        setToken(res.data.token);
         // TODO connect to socket.io, remove memoryHistory.push
         memoryHistory.push("/lobby");
       } else {


### PR DESCRIPTION
Closes #67 

- Adds `token` UUID to Player schema
- Refactors POST /player/create to return a payload of `{ playerId: XXX, token: YYY }`, updating frontend API calls to consume this
- Replaces `validatePlayerId` service with `authenticatePlayer`
- Returns each players `id` on `players:initial`