### PR TITLE
UI layouts for Start of Round and Submit Punchline

### DIFF
--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -6,7 +6,7 @@ import {
   Redirect,
   useParams,
 } from "react-router-dom";
-import { BasicPage, NicknamePage, LobbyPage } from "./pages";
+import { BasicPage, NicknamePage, LobbyPage, StartRoundPage } from "./pages";
 
 type PathParams = {
   gameCode: string;
@@ -27,7 +27,7 @@ const GameRouter = () => {
         </Route>
 
         <Route path="/preRound">
-          <BasicPage gameCode={gameCode} path="preRound" />
+          <StartRoundPage />
         </Route>
 
         <Route path="/submitPunchline">

--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -6,7 +6,13 @@ import {
   Redirect,
   useParams,
 } from "react-router-dom";
-import { BasicPage, NicknamePage, LobbyPage, StartRoundPage } from "./pages";
+import {
+  BasicPage,
+  SubmitPunchlinePage,
+  NicknamePage,
+  LobbyPage,
+  StartRoundPage,
+} from "./pages";
 
 type PathParams = {
   gameCode: string;
@@ -31,7 +37,7 @@ const GameRouter = () => {
         </Route>
 
         <Route path="/submitPunchline">
-          <BasicPage gameCode={gameCode} path="submitPunchline" />
+          <SubmitPunchlinePage />
         </Route>
 
         <Route path="/selectPunchline">

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -23,7 +23,7 @@ const Dropdown = ({ aboveDrop, belowDrop, header }: DropdownProps) => {
       <div className={styles.main}>
         {aboveDrop}
         <div className={styles.heading}>
-          <h4>{header}</h4>
+          <p>{header}</p>
           <IconButton
             icon={faAngleDown}
             handleOnClick={toggleDrop}

--- a/frontend/src/components/Dropdown/style.module.css
+++ b/frontend/src/components/Dropdown/style.module.css
@@ -25,6 +25,7 @@
 .dropHide {
   top: 0;
   transition: 0.3s;
+  visibility: hidden;
   z-index: 0;
 }
 
@@ -32,5 +33,6 @@
   box-shadow: 0px 10px 20px -18px rgba(0, 0, 0, 0.75);
   top: 162px;
   transition: 0.3s;
+  visibility: visible;
   z-index: 10;
 }

--- a/frontend/src/components/PunchlineCard/index.tsx
+++ b/frontend/src/components/PunchlineCard/index.tsx
@@ -26,7 +26,7 @@ const PunchlineCard = ({
     textStyle = styles.textSmall;
   }
 
-  let cardStyle: string = "";
+  let cardStyle: string = styles.punchlineAvailable;
   if (status === "selected") {
     cardStyle = styles.punchlineSelected;
   } else if (status === "submitted") {

--- a/frontend/src/components/PunchlineCard/style.module.css
+++ b/frontend/src/components/PunchlineCard/style.module.css
@@ -1,11 +1,10 @@
 .punchline {
-  background-color: #eeffff;
   border-radius: 16px;
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   height: fit-content;
   margin-bottom: 24px;
-  max-height: 146px; /* This magic number is the height of the longest punchline */
+  max-height: 154px; /* This magic number is the height of the longest punchline */
   min-height: 100px;
   padding: 20px;
   position: relative;
@@ -15,6 +14,11 @@
 .punchline:hover {
   box-shadow: 0px 10px 40px rgba(0, 0, 0, 0.25);
   transition: 0.3s;
+}
+
+.punchlineAvailable {
+  background-color: #eeffff;
+  border: 4px solid #eeffff;
 }
 
 .punchlineSelected {

--- a/frontend/src/pages/StartRoundPage/index.tsx
+++ b/frontend/src/pages/StartRoundPage/index.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
+import Button from "../../components/Button";
+import styles from "./style.module.css";
+
+const LobbyPage = () => {
+  const memoryHistory = useHistory();
+
+  const [isTheMan] = useState(true);
+
+  return (
+    <div className={styles.container}>
+      <h4 className={styles.round}>Round X of X</h4>
+      <div className={styles.theMan}>
+        <p className={styles.theManText}>
+          {isTheMan ? "You are The Man™." : "USERNAME is The Man™."}
+        </p>
+      </div>
+
+      {isTheMan ? (
+        <Button
+          text="Leshgo!"
+          handleOnClick={() => memoryHistory.push("/selectPunchline")}
+        />
+      ) : (
+        <p className={styles.waitingMsg}>Waiting on X to start the round...</p>
+      )}
+    </div>
+  );
+};
+
+export default LobbyPage;

--- a/frontend/src/pages/StartRoundPage/index.tsx
+++ b/frontend/src/pages/StartRoundPage/index.tsx
@@ -20,7 +20,7 @@ const LobbyPage = () => {
       {isTheMan ? (
         <Button
           text="Leshgo!"
-          handleOnClick={() => memoryHistory.push("/selectPunchline")}
+          handleOnClick={() => memoryHistory.push("/submitPunchline")}
         />
       ) : (
         <p className={styles.waitingMsg}>Waiting on X to start the round...</p>

--- a/frontend/src/pages/StartRoundPage/style.module.css
+++ b/frontend/src/pages/StartRoundPage/style.module.css
@@ -1,0 +1,26 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding: 24px;
+}
+
+.round {
+  text-align: center;
+}
+
+.theMan {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+}
+
+.theManText {
+  font-size: 36px;
+  font-style: italic;
+}
+
+.waitingMsg {
+  font-style: italic;
+}

--- a/frontend/src/pages/SubmitPunchlinePage/index.tsx
+++ b/frontend/src/pages/SubmitPunchlinePage/index.tsx
@@ -7,7 +7,7 @@ import ProgressBar from "../../components/ProgressBar";
 import PunchlineCard from "../../components/PunchlineCard";
 import Button from "../../components/Button";
 
-const ChoosePunchlinePage = () => {
+const SubmitPunchlinePage = () => {
   const memoryHistory = useHistory();
 
   const dummyPunchlines: {
@@ -151,4 +151,4 @@ const ChoosePunchlinePage = () => {
   );
 };
 
-export default ChoosePunchlinePage;
+export default SubmitPunchlinePage;

--- a/frontend/src/pages/SubmitPunchlinePage/index.tsx
+++ b/frontend/src/pages/SubmitPunchlinePage/index.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
+import styles from "./style.module.css";
+import Dropdown from "../../components/Dropdown";
+import PlayerList from "../../components/PlayerList";
+import ProgressBar from "../../components/ProgressBar";
+import PunchlineCard from "../../components/PunchlineCard";
+import Button from "../../components/Button";
+
+const ChoosePunchlinePage = () => {
+  const memoryHistory = useHistory();
+
+  const dummyPunchlines: {
+    id: string;
+    text: string;
+    status: "available" | "selected" | "submitted";
+    new?: boolean;
+  }[] = [
+    {
+      id: "1",
+      text: "Me time.",
+      status: "available",
+      new: true,
+    },
+    {
+      id: "2",
+      text:
+        "Looking in the mirror, applying lipstick, and whispering “tonight, you will have sex with Tom Cruise.”",
+      status: "available",
+    },
+    {
+      id: "3",
+      text: "The violation of our most basic human rights.",
+      status: "available",
+    },
+    {
+      id: "4",
+      text:
+        "Getting married, having a few kids, buying some stuff, retiring to Florida, and dying..",
+      status: "available",
+    },
+    {
+      id: "5",
+      text: "Dark and mysterious forces beyond our control.",
+      status: "available",
+    },
+    {
+      id: "6",
+      text: "Not vaccinating my children because I am stupid.",
+      status: "available",
+    },
+    {
+      id: "7",
+      text: "Rap music.",
+      status: "available",
+    },
+    {
+      id: "8",
+      text: "Listening to her problems without trying to solve them.",
+      status: "available",
+    },
+    {
+      id: "9",
+      text: "Preteens.",
+      status: "available",
+    },
+    {
+      id: "10",
+      text: "Alcoholism.",
+      status: "available",
+    },
+  ];
+
+  const [punchlineSelected, setPunchlineSelected] = useState("");
+  const [punchlineSubmitted, setPunchlineSubmitted] = useState("");
+  const [punchlines] = useState(dummyPunchlines);
+
+  const selectPunchline = (text: string) => {
+    if (punchlineSubmitted) {
+      return;
+    }
+    if (text === punchlineSelected) {
+      setPunchlineSelected("");
+    } else {
+      setPunchlineSelected(text);
+    }
+  };
+
+  return (
+    <>
+      <Dropdown
+        aboveDrop={<h4 style={{ textAlign: `center` }}>Round X of X</h4>}
+        belowDrop={<PlayerList gameState="midround" />}
+        header="Scoreboard"
+      />
+      <div className={styles.container}>
+        <div className={styles.spacer}>
+          <h5>The Setup:</h5>
+          <h2>Daddy, why is mommy crying?</h2>
+        </div>
+        <div className={styles.spacer}>
+          <ProgressBar playersChosen={0} playersTotal={0} />
+        </div>
+
+        <h5 style={{ marginBottom: `18px` }}>
+          {punchlineSubmitted ? `Punchline sent!` : `Choose a Punchline:`}
+        </h5>
+        {punchlines.map((punchline) => {
+          let punchlineStatus: "available" | "selected" | "submitted";
+          if (punchline.text === punchlineSubmitted) {
+            punchlineStatus = "submitted";
+          } else if (punchline.text === punchlineSelected) {
+            punchlineStatus = "selected";
+          } else {
+            punchlineStatus = "available";
+          }
+
+          return (
+            <PunchlineCard
+              key={punchline.id}
+              text={punchline.text}
+              handleOnClick={() => selectPunchline(punchline.text)}
+              status={punchlineStatus}
+              newCard={punchline.new}
+            />
+          );
+        })}
+      </div>
+      {punchlineSelected && (
+        <div className={styles.bottomBtns}>
+          <div className={styles.btnNah}>
+            <Button
+              text="Nah"
+              handleOnClick={() => setPunchlineSelected("")}
+              variant="secondary"
+            />
+          </div>
+          <div className={styles.btnSend}>
+            <Button
+              text="Send it"
+              handleOnClick={() => {
+                setPunchlineSubmitted(punchlineSelected);
+                setPunchlineSelected("");
+                memoryHistory.push("/postRound");
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ChoosePunchlinePage;

--- a/frontend/src/pages/SubmitPunchlinePage/style.module.css
+++ b/frontend/src/pages/SubmitPunchlinePage/style.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding: 24px;
+}
+
+.spacer {
+  margin-bottom: 24px;
+}
+
+.bottomBtns {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0.01%,
+    rgba(0, 0, 0, 0.25) 81.77%,
+    rgba(0, 0, 0, 0.25) 100%
+  );
+  bottom: 0;
+  display: flex;
+  position: sticky;
+}
+
+.btnNah {
+  flex: 1 auto 0;
+  margin: 24px 6px 24px 24px;
+}
+
+.btnSend {
+  flex: 1 auto 0;
+  margin: 24px 24px 24px 6px;
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -2,3 +2,4 @@ export { default as BasicPage } from "./BasicPage";
 export { default as HomePage } from "./HomePage";
 export { default as LobbyPage } from "./LobbyPage";
 export { default as NicknamePage } from "./NicknamePage";
+export { default as StartRoundPage } from "./StartRoundPage";

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,4 +1,5 @@
 export { default as BasicPage } from "./BasicPage";
+export { default as SubmitPunchlinePage } from "./SubmitPunchlinePage";
 export { default as HomePage } from "./HomePage";
 export { default as LobbyPage } from "./LobbyPage";
 export { default as NicknamePage } from "./NicknamePage";


### PR DESCRIPTION
Frontend layouts for the first two screens in the user flow of a regular player (not The Man). Players can start the round, select punchlines, and submit them to The Man for judging.

Note that the Scoreboard display in the Dropdown isn't quite right; this will be fixed once the rest of the layouts are complete.

Partially closes #57 