### PR TITLE
Handle Players joining mid-round

### DIFF
--- a/backend/src/handlers/__tests__/game.handler.test.ts
+++ b/backend/src/handlers/__tests__/game.handler.test.ts
@@ -1,10 +1,9 @@
 import { Server, Socket } from "socket.io";
-import { Game, GameState, SetupType } from "../../models";
+import { Game, SetupType } from "../../models";
 import * as GameService from "../../services/game.service";
 import registerGameHandler, {
   assignNextHost,
   emitHost,
-  emitNavigate,
   getActivePlayers,
   getHost,
   getSockets,
@@ -387,36 +386,6 @@ describe("intialiseNextRound handler", () => {
       type: SetupType.pickOne,
     });
     expect(emitMock).toHaveBeenNthCalledWith(3, "navigate", RoundState.before);
-  });
-});
-
-describe("emitNavigate handler", () => {
-  let socket: Socket;
-  let game: Game;
-
-  beforeEach(() => {
-    socket = ({
-      emit: jest.fn(),
-    } as unknown) as Socket;
-
-    game = ({
-      state: GameState.lobby,
-      players: [
-        { nickname: "Bob", new: true },
-        { nickname: "Fred", new: false },
-      ],
-      settings: {
-        roundLimit: 69,
-        maxPlayers: 25,
-      },
-    } as unknown) as Game;
-  });
-
-  it("navigates player to lobby", () => {
-    emitNavigate(socket, game);
-
-    expect(socket.emit).toHaveBeenCalledTimes(1);
-    expect(socket.emit).toHaveBeenCalledWith("navigate", GameState.lobby);
   });
 });
 

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -1,4 +1,4 @@
-import { Game, GameState, Player } from "../models";
+import { Game, Player } from "../models";
 import { Server, Socket } from "socket.io";
 import {
   getGame,
@@ -99,14 +99,6 @@ export const initialiseNextRound = async (
     type: setup.type,
   });
   io.to(gameCode).emit("navigate", RoundState.before);
-};
-
-export const emitNavigate = (socket: Socket, game: Game): void => {
-  switch (game.state) {
-    case GameState.lobby:
-      socket.emit("navigate", GameState.lobby);
-      break;
-  }
 };
 
 export const emitHost = async (io: Server, socket: Socket): Promise<void> => {

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -94,7 +94,10 @@ export const initialiseNextRound = async (
   );
 
   io.to(gameCode).emit("round:number", roundNumber);
-  io.to(gameCode).emit("round:setup", setup);
+  io.to(gameCode).emit("round:setup", {
+    setup: setup.setup,
+    type: setup.type,
+  });
   io.to(gameCode).emit("navigate", RoundState.before);
 };
 

--- a/backend/src/models/round.model.ts
+++ b/backend/src/models/round.model.ts
@@ -13,6 +13,7 @@ export interface Round extends Document {
   setup: Setup;
   host: Player["id"];
   punchlinesByPlayer: Map<Player["id"], string[]>;
+  winner: Player["id"];
   state: RoundState;
 }
 
@@ -20,6 +21,7 @@ export const RoundSchema: Schema = new Schema({
   setup: { type: SetupSchema, required: true },
   host: { type: Types.ObjectId, required: true },
   punchlinesByPlayer: { type: Map, of: [String], default: () => ({}) },
+  winner: Types.ObjectId,
   state: {
     type: String,
     enum: Object.values(RoundState),

--- a/backend/src/services/__tests__/round.service.test.ts
+++ b/backend/src/services/__tests__/round.service.test.ts
@@ -345,6 +345,7 @@ describe("hostChoosesWinner Service", () => {
 
     game = await getGame(game.gameCode);
     expect(game.rounds[0].state).toBe(RoundState.after);
+    expect(game.rounds[0].winner.toString()).toBe(playerId);
     expect(winningPlayerId).toBe(playerId);
 
     const player = game.players.id(winningPlayerId);

--- a/backend/src/services/round.service.ts
+++ b/backend/src/services/round.service.ts
@@ -108,6 +108,7 @@ export const hostChooseWinner = async (
     );
     if (winningEntry !== undefined) {
       round.state = RoundState.after;
+      round.winner = winningEntry[0];
 
       await game.save();
 


### PR DESCRIPTION
Closes #101 

This properly servers players initial game data (such as punchlines in hand, punchlines chosen by other players, etc.) when reconnecting to a game.