### PR TITLE
Proxy API Requests

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,7 +30,7 @@ app.use(
     origin: config.origin,
   })
 );
-app.use(routes);
+app.use("/api", routes);
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   console.log(err.message);
   res.status(500).send("Server Error");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "cosmos": "cosmos",
     "cosmos:export": "cosmos-export"
   },
+  "proxy": "http://localhost:42069",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",

--- a/frontend/src/api/__tests__/createGame.test.ts
+++ b/frontend/src/api/__tests__/createGame.test.ts
@@ -1,7 +1,6 @@
 import mockAxios from "jest-mock-axios";
 import { AxiosError, AxiosResponse } from "axios";
 import createGame from "../createGame";
-import { BASE_URL } from "../axiosCall";
 
 afterEach(() => {
   mockAxios.reset();
@@ -23,7 +22,7 @@ test("should return game code on successful creation", async () => {
   const res = await createGame();
 
   expect(mockAxios.post).toHaveBeenCalledTimes(1);
-  expect(mockAxios.post).toHaveBeenCalledWith(`${BASE_URL}/game/create`);
+  expect(mockAxios.post).toHaveBeenCalledWith(`/api/game/create`);
 
   expect(res).toEqual({
     success: true,
@@ -49,7 +48,7 @@ test("should return error on 500 server error", async () => {
   const res = await createGame();
 
   expect(mockAxios.post).toHaveBeenCalledTimes(1);
-  expect(mockAxios.post).toHaveBeenCalledWith(`${BASE_URL}/game/create`);
+  expect(mockAxios.post).toHaveBeenCalledWith(`/api/game/create`);
 
   expect(res).toEqual({
     success: false,

--- a/frontend/src/api/__tests__/createPlayer.test.ts
+++ b/frontend/src/api/__tests__/createPlayer.test.ts
@@ -1,7 +1,6 @@
 import mockAxios from "jest-mock-axios";
 import { AxiosError, AxiosResponse } from "axios";
 import createPlayer, { Response } from "../createPlayer";
-import { BASE_URL } from "../axiosCall";
 
 const testPlayer = {
   nickname: "test",
@@ -31,11 +30,9 @@ test("should return user id on successful creation", async () => {
   const res = await createPlayer(testPlayer);
 
   expect(mockAxios.post).toHaveBeenCalledTimes(1);
-  expect(mockAxios.post).toHaveBeenCalledWith(
-    `${BASE_URL}/player/create`,
-    undefined,
-    { params: testPlayer }
-  );
+  expect(mockAxios.post).toHaveBeenCalledWith(`/api/player/create`, undefined, {
+    params: testPlayer,
+  });
 
   expect(res).toEqual({
     success: true,
@@ -70,11 +67,9 @@ test("should return error on 400 bad request (invalid code or nickname)", async 
   const res = await createPlayer(testPlayer);
 
   expect(mockAxios.post).toHaveBeenCalledTimes(1);
-  expect(mockAxios.post).toHaveBeenCalledWith(
-    `${BASE_URL}/player/create`,
-    undefined,
-    { params: testPlayer }
-  );
+  expect(mockAxios.post).toHaveBeenCalledWith(`/api/player/create`, undefined, {
+    params: testPlayer,
+  });
 
   expect(res).toEqual({
     success: false,
@@ -100,11 +95,9 @@ test("should return error on 500 server error", async () => {
   const res = await createPlayer(testPlayer);
 
   expect(mockAxios.post).toHaveBeenCalledTimes(1);
-  expect(mockAxios.post).toHaveBeenCalledWith(
-    `${BASE_URL}/player/create`,
-    undefined,
-    { params: testPlayer }
-  );
+  expect(mockAxios.post).toHaveBeenCalledWith(`/api/player/create`, undefined, {
+    params: testPlayer,
+  });
 
   expect(res).toEqual({
     success: false,

--- a/frontend/src/api/__tests__/validateGame.test.ts
+++ b/frontend/src/api/__tests__/validateGame.test.ts
@@ -1,7 +1,6 @@
 import mockAxios from "jest-mock-axios";
 import { AxiosError, AxiosResponse } from "axios";
 import validateGame from "../validateGame";
-import { BASE_URL } from "../axiosCall";
 
 const testGameCode = { gameCode: "12345" };
 
@@ -25,7 +24,7 @@ test("should return success on valid game code", async () => {
   const res = await validateGame(testGameCode);
 
   expect(mockAxios.get).toHaveBeenCalledTimes(1);
-  expect(mockAxios.get).toHaveBeenCalledWith(`${BASE_URL}/game/validate`, {
+  expect(mockAxios.get).toHaveBeenCalledWith(`/api/game/validate`, {
     params: testGameCode,
   });
 
@@ -60,7 +59,7 @@ test("should return error on 404 not found (invalid code)", async () => {
   const res = await validateGame(testGameCode);
 
   expect(mockAxios.get).toHaveBeenCalledTimes(1);
-  expect(mockAxios.get).toHaveBeenCalledWith(`${BASE_URL}/game/validate`, {
+  expect(mockAxios.get).toHaveBeenCalledWith(`/api/game/validate`, {
     params: testGameCode,
   });
 
@@ -88,7 +87,7 @@ test("should return error on 500 server error", async () => {
   const res = await validateGame(testGameCode);
 
   expect(mockAxios.get).toHaveBeenCalledTimes(1);
-  expect(mockAxios.get).toHaveBeenCalledWith(`${BASE_URL}/game/validate`, {
+  expect(mockAxios.get).toHaveBeenCalledWith(`/api/game/validate`, {
     params: testGameCode,
   });
 

--- a/frontend/src/api/axiosCall.ts
+++ b/frontend/src/api/axiosCall.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import ApiResponse from "./ApiResponse";
 
-export const BASE_URL = "http://localhost:42069";
 const SERVER_ERROR_500 = 500;
 
 type Props<Type> = {

--- a/frontend/src/api/createGame.ts
+++ b/frontend/src/api/createGame.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import ApiResponse from "./ApiResponse";
-import axiosCall, { BASE_URL } from "./axiosCall";
+import axiosCall from "./axiosCall";
 
 const CREATED_201 = 201;
 
@@ -10,7 +10,7 @@ const CREATED_201 = 201;
  * 500 - Server Error
  */
 const createGame: () => Promise<ApiResponse<string>> = async () => {
-  const url = `${BASE_URL}/game/create`;
+  const url = `/api/game/create`;
   const axiosMethod = async () =>
     axios.post<unknown, AxiosResponse<string>>(url);
   const acceptedCodes = [CREATED_201];

--- a/frontend/src/api/createPlayer.ts
+++ b/frontend/src/api/createPlayer.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import ApiResponse from "./ApiResponse";
-import axiosCall, { BASE_URL } from "./axiosCall";
+import axiosCall from "./axiosCall";
 
 const CREATED_201 = 201;
 
@@ -35,7 +35,7 @@ const createPlayer: (player: Props) => Promise<ApiResponse<Response>> = async ({
     };
   }
 
-  const url = `${BASE_URL}/player/create`;
+  const url = `/api/player/create`;
   const axiosMethod = async () =>
     axios.post<unknown, AxiosResponse<Response>>(url, undefined, {
       params: {

--- a/frontend/src/api/validateGame.ts
+++ b/frontend/src/api/validateGame.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import ApiResponse from "./ApiResponse";
-import axiosCall, { BASE_URL } from "./axiosCall";
+import axiosCall from "./axiosCall";
 
 const NO_CONTENT_204 = 204;
 
@@ -27,7 +27,7 @@ const validateGame: ({
     };
   }
 
-  const url = `${BASE_URL}/game/validate`;
+  const url = `/api/game/validate`;
   const axiosMethod = async () =>
     axios.get<unknown, AxiosResponse<unknown>>(url, {
       params: { gameCode },

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,7 +1,6 @@
 import io from "socket.io-client";
 
-const URL = "http://localhost:42069";
-const socket = io(URL, {
+const socket = io({
   autoConnect: false,
 });
 


### PR DESCRIPTION
Reconfigures the frontend to proxy API requests from `localhost:3000` to `localhost:42069`.

This change is essential for testing the development app in mobile devices across a local network. Previously, all API requests were absolute paths of `http://localhost:42069/` and thus could not be reached by another device on a local network (which would access the development app through an IP address such as `192.168.1.X:3000`. Now requests are relative and properly proxy to the backend when accessing from mobile devices on a local network.

See [Create React App docs](https://create-react-app.dev/docs/proxying-api-requests-in-development/) for more details.