### PR TITLE
Refactor punchlines context

### DIFF
--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -1,19 +1,19 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Router, Switch, Route, Redirect, useParams } from "react-router-dom";
+import { Redirect, Route, Router, Switch, useParams } from "react-router-dom";
 import { createMemoryHistory } from "history";
 import createPersistedState from "use-persisted-state";
 import {
   EndGamePage,
   EndRoundPage,
-  NicknamePage,
   LobbyPage,
+  NicknamePage,
   SelectPunchlinePage,
   StartRoundPage,
   SubmitPunchlinePage,
 } from "./pages";
 import { useRound } from "./contexts/round";
 import { usePlayers } from "./contexts/players";
-import { usePunchlines } from "./contexts/punchlines";
+import { PunchlinesAction, usePunchlines } from "./contexts/punchlines";
 import { SocketProvider } from "./contexts/socket";
 import io from "socket.io-client";
 
@@ -53,7 +53,7 @@ const useSetupSockets = ({
     removePlayer,
     incrementPlayerScore,
   } = usePlayers();
-  const { addPunchlines } = usePunchlines();
+  const [, dispatchPunchlines] = usePunchlines();
   const {
     setRoundNumber,
     setSetup,
@@ -105,7 +105,19 @@ const useSetupSockets = ({
   );
 
   // Round
-  const handlePunchlinesAdd = useCallback(addPunchlines, [addPunchlines]);
+  const handlePunchlinesAdd = useCallback(
+    (punchlines: string[]) =>
+      dispatchPunchlines({ type: PunchlinesAction.ADD, punchlines }),
+    [dispatchPunchlines]
+  );
+  const handlePunchlinesRemove = useCallback(
+    (punchlines: string[]) =>
+      dispatchPunchlines({
+        type: PunchlinesAction.REMOVE,
+        punchlines,
+      }),
+    [dispatchPunchlines]
+  );
   const handleRoundNumber = useCallback(setRoundNumber, [setRoundNumber]);
   const handleRoundSetup = useCallback(setSetup, [setSetup]);
   const handleRoundIncrementPlayersChosen = useCallback(
@@ -138,6 +150,7 @@ const useSetupSockets = ({
 
     // Round
     socket.on("punchlines:add", handlePunchlinesAdd);
+    socket.on("punchlines:remove", handlePunchlinesRemove);
     socket.on("round:number", handleRoundNumber);
     socket.on("round:setup", handleRoundSetup);
     socket.on(

--- a/frontend/src/contexts/__tests__/punchlines.test.tsx
+++ b/frontend/src/contexts/__tests__/punchlines.test.tsx
@@ -42,167 +42,173 @@ describe("usePunchlines()", () => {
     );
   });
 
-  it("dispatch adds multiple punchlines through", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
+  describe("dispatch()", () => {
+    describe("ADD", () => {
+      it("adds multiple punchlines through", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+
+        let [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.ADD,
+            punchlines: ["Testing 123", "Testing ABC"],
+          })
+        );
+
+        [punchlines] = result.current;
+        expect(punchlines).toEqual([
+          { text: "Testing 123" },
+          { text: "Testing ABC" },
+        ]);
+      });
+
+      it("adds successive punchlines", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+
+        let [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+
+        let [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.ADD,
+            punchlines: ["Testing 123"],
+          })
+        );
+
+        [punchlines] = result.current;
+        expect(punchlines).toEqual([{ text: "Testing 123" }]);
+
+        [, dispatch] = result.current;
+        act(() =>
+          dispatch({ type: PunchlinesAction.ADD, punchlines: ["Testing ABC"] })
+        );
+
+        [punchlines] = result.current;
+        expect(punchlines).toEqual([
+          { text: "Testing 123" },
+          { text: "Testing ABC" },
+        ]);
+      });
+
+      it("does not modify state when adding empty punchlines", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+
+        const [punchlinesInitial] = result.current;
+        expect(punchlinesInitial).toEqual([]);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.ADD,
+            punchlines: [],
+          })
+        );
+
+        const [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+        expect(punchlinesInitial).toBe(punchlines);
+      });
     });
 
-    let [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
+    describe("REMOVE", () => {
+      it("removes multiple punchlines", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+        setupRemoveTest(result);
 
-    const [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.ADD,
-        punchlines: ["Testing 123", "Testing ABC"],
-      })
-    );
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.REMOVE,
+            punchlines: ["Testing 123", "Testing ABC"],
+          })
+        );
 
-    [punchlines] = result.current;
-    expect(punchlines).toEqual([
-      { text: "Testing 123" },
-      { text: "Testing ABC" },
-    ]);
-  });
+        const [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+      });
 
-  it("dispatch adds successive punchlines", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
+      it("removes successive punchlines", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+        setupRemoveTest(result);
+
+        let [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.REMOVE,
+            punchlines: ["Testing ABC"],
+          })
+        );
+
+        let [punchlines] = result.current;
+        expect(punchlines).toEqual([{ text: "Testing 123" }]);
+
+        [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.REMOVE,
+            punchlines: ["Testing 123"],
+          })
+        );
+
+        [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+      });
+
+      it("does not remove non-existent punchline", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+        setupRemoveTest(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.REMOVE,
+            punchlines: ["Testing XYZ"],
+          })
+        );
+
+        const [punchlines] = result.current;
+        expect(punchlines).toEqual([
+          { text: "Testing 123" },
+          { text: "Testing ABC" },
+        ]);
+      });
+
+      it("does not modify state when removing empty punchlines", () => {
+        const { result } = renderHook(() => usePunchlines(), {
+          wrapper: PunchlinesProvider,
+        });
+
+        const [punchlinesInitial] = result.current;
+        expect(punchlinesInitial).toEqual([]);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PunchlinesAction.REMOVE,
+            punchlines: [],
+          })
+        );
+
+        const [punchlines] = result.current;
+        expect(punchlines).toEqual([]);
+        expect(punchlinesInitial).toBe(punchlines);
+      });
     });
-
-    let [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
-
-    let [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.ADD,
-        punchlines: ["Testing 123"],
-      })
-    );
-
-    [punchlines] = result.current;
-    expect(punchlines).toEqual([{ text: "Testing 123" }]);
-
-    [, dispatch] = result.current;
-    act(() =>
-      dispatch({ type: PunchlinesAction.ADD, punchlines: ["Testing ABC"] })
-    );
-
-    [punchlines] = result.current;
-    expect(punchlines).toEqual([
-      { text: "Testing 123" },
-      { text: "Testing ABC" },
-    ]);
-  });
-
-  it("dispatch does not modify state when adding empty punchlines", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
-    });
-
-    const [punchlinesInitial] = result.current;
-    expect(punchlinesInitial).toEqual([]);
-
-    const [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.ADD,
-        punchlines: [],
-      })
-    );
-
-    const [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
-    expect(punchlinesInitial).toBe(punchlines);
-  });
-
-  it("dispatch removes multiple punchlines", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
-    });
-    setupRemoveTest(result);
-
-    const [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.REMOVE,
-        punchlines: ["Testing 123", "Testing ABC"],
-      })
-    );
-
-    const [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
-  });
-
-  it("dispatch removes successive punchlines", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
-    });
-    setupRemoveTest(result);
-
-    let [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.REMOVE,
-        punchlines: ["Testing ABC"],
-      })
-    );
-
-    let [punchlines] = result.current;
-    expect(punchlines).toEqual([{ text: "Testing 123" }]);
-
-    [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.REMOVE,
-        punchlines: ["Testing 123"],
-      })
-    );
-
-    [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
-  });
-
-  it("dispatch does not remove nonexistent punchline", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
-    });
-    setupRemoveTest(result);
-
-    const [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.REMOVE,
-        punchlines: ["Testing XYZ"],
-      })
-    );
-
-    const [punchlines] = result.current;
-    expect(punchlines).toEqual([
-      { text: "Testing 123" },
-      { text: "Testing ABC" },
-    ]);
-  });
-
-  it("dispatch does not modify state when removing empty punchlines", () => {
-    const { result } = renderHook(() => usePunchlines(), {
-      wrapper: PunchlinesProvider,
-    });
-
-    const [punchlinesInitial] = result.current;
-    expect(punchlinesInitial).toEqual([]);
-
-    const [, dispatch] = result.current;
-    act(() =>
-      dispatch({
-        type: PunchlinesAction.REMOVE,
-        punchlines: [],
-      })
-    );
-
-    const [punchlines] = result.current;
-    expect(punchlines).toEqual([]);
-    expect(punchlinesInitial).toBe(punchlines);
   });
 });

--- a/frontend/src/contexts/__tests__/punchlines.test.tsx
+++ b/frontend/src/contexts/__tests__/punchlines.test.tsx
@@ -194,8 +194,8 @@ describe("usePunchlines()", () => {
           wrapper: PunchlinesProvider,
         });
 
-        const [punchlinesInitial] = result.current;
-        expect(punchlinesInitial).toEqual([]);
+        const [initialPunchlines] = result.current;
+        expect(initialPunchlines).toEqual([]);
 
         const [, dispatch] = result.current;
         act(() =>
@@ -207,7 +207,7 @@ describe("usePunchlines()", () => {
 
         const [punchlines] = result.current;
         expect(punchlines).toEqual([]);
-        expect(punchlinesInitial).toBe(punchlines);
+        expect(punchlines).toBe(initialPunchlines);
       });
     });
   });

--- a/frontend/src/pages/SubmitPunchlinePage/index.tsx
+++ b/frontend/src/pages/SubmitPunchlinePage/index.tsx
@@ -60,7 +60,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
         }
       );
     }
-  }, [dispatchPunchlines, incrementPlayersChosen, punchlineSelected]);
+  }, [dispatchPunchlines, incrementPlayersChosen, punchlineSelected, socket]);
 
   return (
     <>


### PR DESCRIPTION
This a child issue of #131. See the parent issue for greater context (pun intended) on the rationale for this change.

### Summary of changes

- Converts `PunchlinesProvider` to `useReducer()` internally.
  - This removes callbacks `initialisePunchlines()`, `addPunchlines()`, and `removePunchlines()`.
  - The reducer includes two actions; `ADD` and `REMOVE`.
    - Note: `initialisePunchlines()` was an unused function which is why an action was not provided for the functionality of resetting previous state while adding new punchlines. This functionality may need to be added as part of #101, however is out of scope for this PR.
  - `PunchlinesProvider` now returns a tuple consisting of the state object (an array of type `Punchline`) and dispatch function.
  - Improves testing to include 100% coverage for `src/contexts/punchlines.tsx`

### Notes

- This PR enables some of the foundations required in the frontend for #138.
- This PR completely disables the `new` flag for punchlines. I have attached a comment to #139 to document this change. It is my intention that #139 can re-enable the `new` flag once a bug-free solution has been developed. Fixing it in this PR is deemed out of scope.