### PR TITLE
Add useSetupSocketHandlers() hook

### DIFF
--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Redirect, Route, Router, Switch, useParams } from "react-router-dom";
 import { createMemoryHistory } from "history";
-import createPersistedState from "use-persisted-state";
 import {
   EndGamePage,
   EndRoundPage,
@@ -11,11 +10,9 @@ import {
   StartRoundPage,
   SubmitPunchlinePage,
 } from "./pages";
-import { useRound } from "./contexts/round";
-import { usePlayers } from "./contexts/players";
-import { PunchlinesAction, usePunchlines } from "./contexts/punchlines";
 import { SocketProvider } from "./contexts/socket";
 import io from "socket.io-client";
+import { useSetupSocketHandlers } from "./hooks/socket";
 
 const socket = io({
   autoConnect: false,
@@ -31,161 +28,9 @@ type PathParams = {
 };
 
 const memoryHistory = createMemoryHistory();
-const usePlayerIdState = createPersistedState("playerId");
-const useTokenState = createPersistedState("token");
 
 const INITIAL_ROUND_LIMIT = 69;
 const INITIAL_MAX_PLAYERS = 40;
-
-const useSetupSockets = ({
-  settings,
-  setSettings,
-}: {
-  settings: Settings;
-  setSettings: React.Dispatch<React.SetStateAction<Settings>>;
-}) => {
-  const [, setPlayerId] = usePlayerIdState("");
-  const [, setToken] = useTokenState("");
-  const {
-    setHost,
-    initialisePlayers,
-    addPlayer,
-    removePlayer,
-    incrementPlayerScore,
-  } = usePlayers();
-  const [, dispatchPunchlines] = usePunchlines();
-  const {
-    setRoundNumber,
-    setSetup,
-    incrementPlayersChosen,
-    setPunchlinesChosen,
-    setWinner,
-  } = useRound();
-
-  // Connection
-  const handleNavigate = useCallback(
-    (path: string) => memoryHistory.push(path.toLowerCase()),
-    []
-  );
-  const handleHost = useCallback(setHost, [setHost]);
-  const handlePlayersInitial = useCallback(initialisePlayers, [
-    initialisePlayers,
-  ]);
-  const handleSettingsInitial = useCallback(setSettings, [setSettings]);
-  const handleConnectError = useCallback(() => {
-    setPlayerId("");
-    setToken("");
-  }, [setPlayerId, setToken]);
-
-  // Lobby
-  const handlePlayersAdd = useCallback(addPlayer, [addPlayer]);
-  const handlePlayersRemove = useCallback(removePlayer, [removePlayer]);
-  const handleSettingsUpdate = useCallback(
-    (setting, value) => {
-      let key;
-      switch (setting) {
-        case "MAX_PLAYERS":
-          key = "maxPlayers";
-          break;
-        case "ROUND_LIMIT":
-          key = "roundLimit";
-          break;
-        default:
-          key = null;
-      }
-      if (key !== null) {
-        const newSettings = {
-          ...settings,
-          [key]: value,
-        };
-        setSettings(newSettings);
-      }
-    },
-    [setSettings, settings]
-  );
-
-  // Round
-  const handlePunchlinesAdd = useCallback(
-    (punchlines: string[]) =>
-      dispatchPunchlines({ type: PunchlinesAction.ADD, punchlines }),
-    [dispatchPunchlines]
-  );
-  const handlePunchlinesRemove = useCallback(
-    (punchlines: string[]) =>
-      dispatchPunchlines({
-        type: PunchlinesAction.REMOVE,
-        punchlines,
-      }),
-    [dispatchPunchlines]
-  );
-  const handleRoundNumber = useCallback(setRoundNumber, [setRoundNumber]);
-  const handleRoundSetup = useCallback(setSetup, [setSetup]);
-  const handleRoundIncrementPlayersChosen = useCallback(
-    incrementPlayersChosen,
-    [incrementPlayersChosen]
-  );
-  const handleRoundChosenPunchlines = useCallback(setPunchlinesChosen, [
-    setPunchlinesChosen,
-  ]);
-  const handleRoundWinner = useCallback(
-    (winningPlayerId: string, winningPunchlines: string[]) => {
-      setWinner(winningPlayerId, winningPunchlines);
-      incrementPlayerScore(winningPlayerId);
-    },
-    [incrementPlayerScore, setWinner]
-  );
-
-  useEffect(() => {
-    // Connection
-    socket.on("navigate", handleNavigate);
-    socket.on("host", handleHost);
-    socket.on("players:initial", handlePlayersInitial);
-    socket.on("settings:initial", handleSettingsInitial);
-    socket.on("connect_error", handleConnectError);
-
-    // Lobby
-    socket.on("players:add", handlePlayersAdd);
-    socket.on("players:remove", handlePlayersRemove);
-    socket.on("settings:update", handleSettingsUpdate);
-
-    // Round
-    socket.on("punchlines:add", handlePunchlinesAdd);
-    socket.on("punchlines:remove", handlePunchlinesRemove);
-    socket.on("round:number", handleRoundNumber);
-    socket.on("round:setup", handleRoundSetup);
-    socket.on(
-      "round:increment-players-chosen",
-      handleRoundIncrementPlayersChosen
-    );
-    socket.on("round:chosen-punchlines", handleRoundChosenPunchlines);
-    socket.on("round:winner", handleRoundWinner);
-    return () => {
-      // Remove event handlers when component is unmounted to prevent buildup of identical handlers
-      // Connection
-      socket.off("navigate", handleNavigate);
-      socket.off("host", handleHost);
-      socket.off("players:initial", handlePlayersInitial);
-      socket.off("settings:initial", handleSettingsInitial);
-      socket.off("connect_error", handleConnectError);
-
-      // Lobby
-      socket.off("players:add", handlePlayersAdd);
-      socket.off("players:remove", handlePlayersRemove);
-      socket.off("settings:update", handleSettingsUpdate);
-
-      // Round
-      socket.off("punchlines:add", handlePunchlinesAdd);
-      socket.off("round:number", handleRoundNumber);
-      socket.off("round:setup", handleRoundSetup);
-      socket.off(
-        "round:increment-players-chosen",
-        handleRoundIncrementPlayersChosen
-      );
-      socket.off("round:chosen-punchlines", handleRoundChosenPunchlines);
-      socket.off("round:winner", handleRoundWinner);
-    };
-  });
-};
 
 const GameRouter = () => {
   const { gameCode } = useParams<PathParams>();
@@ -194,10 +39,7 @@ const GameRouter = () => {
     maxPlayers: INITIAL_MAX_PLAYERS,
   });
 
-  useSetupSockets({
-    settings,
-    setSettings,
-  });
+  useSetupSocketHandlers(socket, memoryHistory, settings, setSettings);
 
   return (
     <SocketProvider socket={socket}>

--- a/frontend/src/hooks/socket.ts
+++ b/frontend/src/hooks/socket.ts
@@ -1,0 +1,160 @@
+import React, { useCallback, useEffect } from "react";
+import { usePlayers } from "../contexts/players";
+import { PunchlinesAction, usePunchlines } from "../contexts/punchlines";
+import { useRound } from "../contexts/round";
+import { Settings } from "../GameRouter";
+import createPersistedState from "use-persisted-state";
+import { Socket } from "socket.io-client";
+import { MemoryHistory } from "history";
+
+const usePlayerIdState = createPersistedState("playerId");
+const useTokenState = createPersistedState("token");
+
+export const useSetupSocketHandlers = (
+  socket: Socket,
+  memoryHistory: MemoryHistory,
+  settings: Settings,
+  setSettings: React.Dispatch<React.SetStateAction<Settings>>
+) => {
+  const [, setPlayerId] = usePlayerIdState("");
+  const [, setToken] = useTokenState("");
+  const {
+    setHost,
+    initialisePlayers,
+    addPlayer,
+    removePlayer,
+    incrementPlayerScore,
+  } = usePlayers();
+  const [, dispatchPunchlines] = usePunchlines();
+  const {
+    setRoundNumber,
+    setSetup,
+    incrementPlayersChosen,
+    setPunchlinesChosen,
+    setWinner,
+  } = useRound();
+
+  // Connection
+  const handleNavigate = useCallback(
+    (path: string) => memoryHistory.push(path.toLowerCase()),
+    [memoryHistory]
+  );
+  const handleHost = useCallback(setHost, [setHost]);
+  const handlePlayersInitial = useCallback(initialisePlayers, [
+    initialisePlayers,
+  ]);
+  const handleSettingsInitial = useCallback(setSettings, [setSettings]);
+  const handleConnectError = useCallback(() => {
+    setPlayerId("");
+    setToken("");
+  }, [setPlayerId, setToken]);
+
+  // Lobby
+  const handlePlayersAdd = useCallback(addPlayer, [addPlayer]);
+  const handlePlayersRemove = useCallback(removePlayer, [removePlayer]);
+  const handleSettingsUpdate = useCallback(
+    (setting, value) => {
+      let key;
+      switch (setting) {
+        case "MAX_PLAYERS":
+          key = "maxPlayers";
+          break;
+        case "ROUND_LIMIT":
+          key = "roundLimit";
+          break;
+        default:
+          key = null;
+      }
+      if (key !== null) {
+        const newSettings = {
+          ...settings,
+          [key]: value,
+        };
+        setSettings(newSettings);
+      }
+    },
+    [setSettings, settings]
+  );
+
+  // Round
+  const handlePunchlinesAdd = useCallback(
+    (punchlines: string[]) =>
+      dispatchPunchlines({ type: PunchlinesAction.ADD, punchlines }),
+    [dispatchPunchlines]
+  );
+  const handlePunchlinesRemove = useCallback(
+    (punchlines: string[]) =>
+      dispatchPunchlines({
+        type: PunchlinesAction.REMOVE,
+        punchlines,
+      }),
+    [dispatchPunchlines]
+  );
+  const handleRoundNumber = useCallback(setRoundNumber, [setRoundNumber]);
+  const handleRoundSetup = useCallback(setSetup, [setSetup]);
+  const handleRoundIncrementPlayersChosen = useCallback(
+    incrementPlayersChosen,
+    [incrementPlayersChosen]
+  );
+  const handleRoundChosenPunchlines = useCallback(setPunchlinesChosen, [
+    setPunchlinesChosen,
+  ]);
+  const handleRoundWinner = useCallback(
+    (winningPlayerId: string, winningPunchlines: string[]) => {
+      setWinner(winningPlayerId, winningPunchlines);
+      incrementPlayerScore(winningPlayerId);
+    },
+    [incrementPlayerScore, setWinner]
+  );
+
+  useEffect(() => {
+    // Connection
+    socket.on("navigate", handleNavigate);
+    socket.on("host", handleHost);
+    socket.on("players:initial", handlePlayersInitial);
+    socket.on("settings:initial", handleSettingsInitial);
+    socket.on("connect_error", handleConnectError);
+
+    // Lobby
+    socket.on("players:add", handlePlayersAdd);
+    socket.on("players:remove", handlePlayersRemove);
+    socket.on("settings:update", handleSettingsUpdate);
+
+    // Round
+    socket.on("punchlines:add", handlePunchlinesAdd);
+    socket.on("punchlines:remove", handlePunchlinesRemove);
+    socket.on("round:number", handleRoundNumber);
+    socket.on("round:setup", handleRoundSetup);
+    socket.on(
+      "round:increment-players-chosen",
+      handleRoundIncrementPlayersChosen
+    );
+    socket.on("round:chosen-punchlines", handleRoundChosenPunchlines);
+    socket.on("round:winner", handleRoundWinner);
+    return () => {
+      // Remove event handlers when component is unmounted to prevent buildup of identical handlers
+      // Connection
+      socket.off("navigate", handleNavigate);
+      socket.off("host", handleHost);
+      socket.off("players:initial", handlePlayersInitial);
+      socket.off("settings:initial", handleSettingsInitial);
+      socket.off("connect_error", handleConnectError);
+
+      // Lobby
+      socket.off("players:add", handlePlayersAdd);
+      socket.off("players:remove", handlePlayersRemove);
+      socket.off("settings:update", handleSettingsUpdate);
+
+      // Round
+      socket.off("punchlines:add", handlePunchlinesAdd);
+      socket.off("round:number", handleRoundNumber);
+      socket.off("round:setup", handleRoundSetup);
+      socket.off(
+        "round:increment-players-chosen",
+        handleRoundIncrementPlayersChosen
+      );
+      socket.off("round:chosen-punchlines", handleRoundChosenPunchlines);
+      socket.off("round:winner", handleRoundWinner);
+    };
+  });
+};


### PR DESCRIPTION
`src/GameRouter.tsx` was getting quite unwieldy. This is a simple change that creates a clear separation between `GameRouter` (probably due to be renamed `GameApp` or similar in the future) and `useSetupSocketHandlers()`. While both are due for more refactoring down the line, I think this is a good change for now.