### PR TITLE
Refactor players context

### DIFF
--- a/frontend/src/components/PlayerList/index.tsx
+++ b/frontend/src/components/PlayerList/index.tsx
@@ -12,7 +12,7 @@ interface PlayerListProps {
 }
 
 const PlayerList = ({ gameState }: PlayerListProps) => {
-  const { host, players } = usePlayers();
+  const [{ host, players, count }] = usePlayers();
   const [playerId] = usePlayerIdState("");
 
   const isHost = (player: PlayerType) => player.id === host;
@@ -26,18 +26,20 @@ const PlayerList = ({ gameState }: PlayerListProps) => {
     showHost = true;
   }
 
+  const playersList = Object.values(players);
+
   return (
     <div className={styles.playerlist}>
-      {players.map((player, index) => (
+      {playersList.map((player, index) => (
         <Player
           key={player.id}
           nickname={player.nickname}
           score={showScores ? player.score : undefined}
           highlight={isMe(player)}
           divider={
-            index + 1 < players.length && // player not last
+            index + 1 < count && // player not last
             !isMe(player) && // player not me
-            !isMe(players[index + 1]) // next player not me
+            !isMe(playersList[index + 1]) // next player not me
           }
           isHost={showHost ? isHost(player) : undefined}
         />

--- a/frontend/src/contexts/__tests__/players.test.tsx
+++ b/frontend/src/contexts/__tests__/players.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook } from "@testing-library/react-hooks";
-import { PlayersProvider, usePlayers } from "../players";
+import { act, renderHook, RenderResult } from "@testing-library/react-hooks";
+import { PlayersActions, PlayersProvider, usePlayers } from "../players";
 
 describe("usePlayers()", () => {
   it("returns players context when used inside PlayerProvider", () => {
@@ -7,9 +7,11 @@ describe("usePlayers()", () => {
       wrapper: PlayersProvider,
     });
 
-    const { players, host } = result.current;
-    expect(players).toEqual([]);
-    expect(host).toBe("");
+    const [{ players, host, count }, dispatch] = result.current;
+    expect(players).toEqual({});
+    expect(host).toBe(undefined);
+    expect(count).toBe(0);
+    expect(dispatch).toBeDefined();
   });
 
   it("throws error when used outside PlayerProvider", () => {
@@ -18,5 +20,218 @@ describe("usePlayers()", () => {
     expect(result.error).toEqual(
       Error("usePlayers() must be used within a PlayersProvider")
     );
+  });
+
+  describe("dispatch()", () => {
+    const setupPlayer = (
+      result: RenderResult<ReturnType<typeof usePlayers>>
+    ) => {
+      const [, dispatch] = result.current;
+      act(() =>
+        dispatch({
+          type: PlayersActions.ADD,
+          id: "123",
+          nickname: "Digits",
+        })
+      );
+
+      const [{ players, host, count }] = result.current;
+      expect(players).toEqual({
+        "123": {
+          id: "123",
+          nickname: "Digits",
+          score: 0,
+        },
+      });
+      expect(host).toBe(undefined);
+      expect(count).toBe(1);
+    };
+
+    describe("INITIALISE", () => {
+      it("sets players and count while preserving host", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PlayersActions.INITIALISE,
+            players: [
+              { id: "123", nickname: "Digits", score: 0 },
+              { id: "abc", nickname: "Letters", score: 3 },
+            ],
+          })
+        );
+
+        const [{ players, host, count }] = result.current;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Digits",
+            score: 0,
+          },
+          abc: {
+            id: "abc",
+            nickname: "Letters",
+            score: 3,
+          },
+        });
+        expect(host).toBe(undefined);
+        expect(count).toBe(2);
+      });
+    });
+
+    describe("ADD", () => {
+      it("adds new player and increments count", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+
+        setupPlayer(result);
+      });
+
+      it("overwrites existing player and maintains count", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: PlayersActions.ADD,
+            id: "123",
+            nickname: "Numerals",
+          })
+        );
+
+        const [{ players, host, count }] = result.current;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Numerals",
+            score: 0,
+          },
+        });
+        expect(host).toBe(undefined);
+        expect(count).toBe(1);
+      });
+    });
+
+    describe("REMOVE", () => {
+      it("removes existing player and decrements count", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [, dispatch] = result.current;
+        act(() => dispatch({ type: PlayersActions.REMOVE, id: "123" }));
+
+        const [{ players, host, count }] = result.current;
+        expect(players).toEqual({});
+        expect(host).toBe(undefined);
+        expect(count).toBe(0);
+      });
+
+      it("does not modify state object if player does not exist", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [initialState, dispatch] = result.current;
+        act(() => dispatch({ type: PlayersActions.REMOVE, id: "abc" }));
+
+        const [state] = result.current;
+        const { players, host, count } = state;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Digits",
+            score: 0,
+          },
+        });
+        expect(host).toBe(undefined);
+        expect(count).toBe(1);
+        expect(state).toBe(initialState);
+      });
+    });
+
+    describe("INCREMENT_SCORE", () => {
+      it("increases score for existent player", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({ type: PlayersActions.INCREMENT_SCORE, id: "123" })
+        );
+
+        const [state] = result.current;
+        const { players, host, count } = state;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Digits",
+            score: 1,
+          },
+        });
+        expect(host).toBe(undefined);
+        expect(count).toBe(1);
+      });
+
+      it("does not modify state object if player does not exist", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [initialState, dispatch] = result.current;
+        act(() =>
+          dispatch({ type: PlayersActions.INCREMENT_SCORE, id: "abc" })
+        );
+
+        const [state] = result.current;
+        const { players, host, count } = state;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Digits",
+            score: 0,
+          },
+        });
+        expect(host).toBe(undefined);
+        expect(count).toBe(1);
+        expect(state).toBe(initialState);
+      });
+    });
+
+    describe("SET_HOST", () => {
+      it("sets host regardless of if player exists", () => {
+        const { result } = renderHook(() => usePlayers(), {
+          wrapper: PlayersProvider,
+        });
+        setupPlayer(result);
+
+        const [, dispatch] = result.current;
+        act(() => dispatch({ type: PlayersActions.SET_HOST, id: "abc" }));
+
+        const [state] = result.current;
+        const { players, host, count } = state;
+        expect(players).toEqual({
+          "123": {
+            id: "123",
+            nickname: "Digits",
+            score: 0,
+          },
+        });
+        expect(host).toBe("abc");
+        expect(count).toBe(1);
+      });
+    });
   });
 });

--- a/frontend/src/contexts/players.tsx
+++ b/frontend/src/contexts/players.tsx
@@ -1,99 +1,109 @@
 import React, {
+  Dispatch,
   PropsWithChildren,
-  useCallback,
   useContext,
-  useMemo,
-  useState,
+  useReducer,
 } from "react";
-import useCrud from "../hooks/useCrud";
 import { Player } from "../types";
 
-type PlayersContextType = {
-  host: string;
-  setHost: (host: string) => void;
-  players: Player[];
-  initialisePlayers: (players: Player[]) => void;
-  addPlayer: (id: string, nickname: string) => void;
-  removePlayer: (playerId: string) => void;
-  incrementPlayerScore: (playerId: string) => void;
+export enum PlayersActions {
+  INITIALISE = "initialise",
+  ADD = "add",
+  REMOVE = "remove",
+  INCREMENT_SCORE = "increment_score",
+  SET_HOST = "set_host",
+}
+
+type PlayersActionType =
+  | { type: PlayersActions.INITIALISE; players: Player[] }
+  | { type: PlayersActions.ADD; id: Player["id"]; nickname: Player["nickname"] }
+  | { type: PlayersActions.REMOVE; id: Player["id"] }
+  | { type: PlayersActions.INCREMENT_SCORE; id: Player["id"] }
+  | { type: PlayersActions.SET_HOST; id: Player["id"] };
+
+type PlayersState = {
+  players: {
+    [id: Player["id"]]: Player;
+  };
+  host: Player["id"] | undefined;
+  count: number;
 };
+
+const reducer = (
+  state: PlayersState,
+  action: PlayersActionType
+): PlayersState => {
+  switch (action.type) {
+    case PlayersActions.INITIALISE: {
+      const { players } = action;
+      return {
+        ...state,
+        players: Object.fromEntries(
+          players.map((player) => [player.id, player])
+        ),
+        count: players.length,
+      };
+    }
+
+    case PlayersActions.ADD: {
+      const { id, nickname } = action;
+      const playerExists = id in state.players;
+      return {
+        ...state,
+        players: {
+          ...state.players,
+          [id]: { id, nickname, score: 0 },
+        },
+        count: playerExists ? state.count : state.count + 1,
+      };
+    }
+
+    case PlayersActions.REMOVE: {
+      const { id } = action;
+      const players = { ...state.players };
+      if (id in players) {
+        delete players[id];
+        return {
+          ...state,
+          players,
+          count: state.count - 1,
+        };
+      }
+      return state;
+    }
+
+    case PlayersActions.INCREMENT_SCORE: {
+      const { id } = action;
+      const players = state.players;
+      if (id in players) {
+        const player = players[id];
+        return {
+          ...state,
+          players: { ...players, [id]: { ...player, score: player.score + 1 } },
+        };
+      }
+      return state;
+    }
+
+    case PlayersActions.SET_HOST: {
+      return { ...state, host: action.id };
+    }
+  }
+};
+
+type PlayersContextType = [PlayersState, Dispatch<PlayersActionType>];
 
 const PlayersContext = React.createContext<PlayersContextType | undefined>(
   undefined
 );
 
-const equals = (player1: Player, player2: Player) => player1.id === player2.id;
-
 export const PlayersProvider = ({ children }: PropsWithChildren<unknown>) => {
-  const [host, setHost] = useState("");
+  const context = useReducer(reducer, {
+    players: {},
+    host: undefined,
+    count: 0,
+  });
 
-  const {
-    items: players,
-    initialiseItems: initialisePlayers,
-    addItem,
-    removeItem,
-    updateItem,
-  } = useCrud<Player>(equals);
-
-  const addPlayer = useCallback(
-    (id: string, nickname: string) =>
-      addItem({
-        nickname,
-        id,
-        score: 0,
-      }),
-    [addItem]
-  );
-
-  const removePlayer = useCallback(
-    (playerId: string) => {
-      const playerToRemove = players.find((player) => player.id === playerId);
-      if (!playerToRemove) {
-        return;
-      }
-
-      removeItem(playerToRemove);
-    },
-    [players, removeItem]
-  );
-
-  const incrementPlayerScore = useCallback(
-    (playerId: string) => {
-      const playerToUpdate = players.find((player) => player.id === playerId);
-      if (!playerToUpdate) {
-        return;
-      }
-
-      updateItem({
-        ...playerToUpdate,
-        score: playerToUpdate.score + 1,
-      });
-    },
-    [players, updateItem]
-  );
-
-  // The context value that will be supplied to any descendants of this component.
-  const context = useMemo(
-    () => ({
-      host,
-      setHost: (newHost: string) => setHost(newHost),
-      players,
-      initialisePlayers,
-      addPlayer,
-      removePlayer,
-      incrementPlayerScore,
-    }),
-    [
-      addPlayer,
-      host,
-      incrementPlayerScore,
-      initialisePlayers,
-      players,
-      removePlayer,
-    ]
-  );
-
-  // Wraps the given child components in a Provider for the above context.
   return (
     <PlayersContext.Provider value={context}>
       {children}
@@ -102,11 +112,11 @@ export const PlayersProvider = ({ children }: PropsWithChildren<unknown>) => {
 };
 
 export const usePlayers = (): PlayersContextType => {
-  const players = useContext(PlayersContext);
+  const context = useContext(PlayersContext);
 
-  if (players === undefined) {
+  if (context === undefined) {
     throw new Error("usePlayers() must be used within a PlayersProvider");
   }
 
-  return players;
+  return context;
 };

--- a/frontend/src/pages/EndRoundPage/index.tsx
+++ b/frontend/src/pages/EndRoundPage/index.tsx
@@ -14,7 +14,7 @@ const EndRoundPage = ({ roundLimit }: { roundLimit: number }) => {
   const socket = useSocket();
   const [, setResponse] = useState("");
 
-  const { host } = usePlayers();
+  const [{ host }] = usePlayers();
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
 

--- a/frontend/src/pages/LobbyPage/index.tsx
+++ b/frontend/src/pages/LobbyPage/index.tsx
@@ -23,7 +23,7 @@ const LobbyPage = ({ gameCode, settings }: Props) => {
   const [, setResponse] = useState("");
   const socket = useSocket();
 
-  const { host, players } = usePlayers();
+  const [{ host, count }] = usePlayers();
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
 
@@ -119,7 +119,7 @@ const LobbyPage = ({ gameCode, settings }: Props) => {
       />
       <div className={styles.container}>
         <div className={styles.main}>
-          <h2>Players ({players.length})</h2>
+          <h2>Players ({count})</h2>
           <PlayerList gameState="lobby" />
         </div>
 
@@ -128,7 +128,7 @@ const LobbyPage = ({ gameCode, settings }: Props) => {
             onClick={() =>
               socket.emit("start", (response: string) => setResponse(response))
             }
-            disabled={players.length < MINIMUM_PLAYERS}
+            disabled={count < MINIMUM_PLAYERS}
           >
             Start game
           </Button>

--- a/frontend/src/pages/SelectPunchlinePage/index.tsx
+++ b/frontend/src/pages/SelectPunchlinePage/index.tsx
@@ -17,7 +17,7 @@ const SelectPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
   const socket = useSocket();
   const [, setResponse] = useState("");
 
-  const { host, players } = usePlayers();
+  const [{ host, count }] = usePlayers();
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
 
@@ -103,10 +103,7 @@ const SelectPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
         <Setup setupText={setup.setup} />
 
         {waiting && (
-          <ProgressBar
-            playersChosen={numPlayersChosen}
-            playersTotal={players.length}
-          />
+          <ProgressBar playersChosen={numPlayersChosen} playersTotal={count} />
         )}
 
         {punchlines &&

--- a/frontend/src/pages/StartRoundPage/index.tsx
+++ b/frontend/src/pages/StartRoundPage/index.tsx
@@ -9,7 +9,7 @@ import { useSocket } from "../../contexts/socket";
 const usePlayerIdState = createPersistedState("playerId");
 
 const StartRoundPage = ({ roundLimit }: { roundLimit: number }) => {
-  const { host, players } = usePlayers();
+  const [{ host, players }] = usePlayers();
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
   const [, setResponse] = useState("");
@@ -25,7 +25,9 @@ const StartRoundPage = ({ roundLimit }: { roundLimit: number }) => {
         <p className={styles.theManText}>
           {playerIsHost
             ? "You are The Man™."
-            : `${players.find((p) => p.id === host)?.nickname} is The Man™.`}
+            : `${
+                host && players[host] ? players[host] : "No-one"
+              } is The Man™.`}
         </p>
       </div>
 
@@ -41,8 +43,8 @@ const StartRoundPage = ({ roundLimit }: { roundLimit: number }) => {
         </Button>
       ) : (
         <p className={styles.waitingMsg}>
-          Waiting on {players.find((p) => p.id === host)?.nickname} to start the
-          round...
+          Waiting on {host && players[host] ? players[host].nickname : "No-one"}{" "}
+          to start the round...
         </p>
       )}
     </div>

--- a/frontend/src/pages/SubmitPunchlinePage/index.tsx
+++ b/frontend/src/pages/SubmitPunchlinePage/index.tsx
@@ -19,7 +19,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
   const [, setResponse] = useState("");
   const socket = useSocket();
 
-  const { host, players } = usePlayers();
+  const [{ host, count }] = usePlayers();
   const [punchlines, dispatchPunchlines] = usePunchlines();
   const { roundNumber, setup, numPlayersChosen, incrementPlayersChosen } =
     useRound();
@@ -78,7 +78,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
 
         <ProgressBar
           playersChosen={numPlayersChosen}
-          playersTotal={players.length - 1}
+          playersTotal={count - 1}
         />
 
         <h5 style={{ margin: `18px 0` }}>


### PR DESCRIPTION
This a child issue of #131. See the parent issue for greater context (pun intended) on the rationale for this change.

### Summary of changes

- Converts `PlayersProvider` to `useReducer()` internally.
  - This removes callbacks `setHost()`, `initialisePlayers()`, `addPlayer()`, `removePlayer()`, and `incrementPlayerScore()`.
  - The reducer includes five actions: `SET_HOST`, `INITIALISE`, `ADD`, `REMOVE`, and `INCREMENT_SCORE`.
  - `PlayersProvider` now returns a tuple consisting of the state object and dispatch function.
    - The state object contains keys for `players`, `host` and `count`.
      - `players` is an object where keys are player IDs and the value is an object of type `Player`. This allows constant-time lookups of players, and improvement from previous where `players` was an array and a linear search was required to find a given player. This has resulted in some of the changes on `PlayerList` and `StartRoundPage`.
      - `host` is a string representing the ID of the player that is the host. Allows constant-time lookups of the host `Player` object through `players` above.
      - `count` is the number of players active in the game. Previously this could be derived from the length of the `players` array, but the change to using an object for `players` makes this approach cleaner for pages where only the number of players is required such as `LobbyPage`, `SelectPunchlinesPage`, and `SubmitPunchlinesPage`.
  - Improves testing to include 100% coverage for `src/contexts/players.tsx`

### Notes

- Once merged this PR will allow the removal of the `useCrud()` hook which I will complete as a seperate PR.