### PR TITLE
Refactor round context

### DIFF
--- a/frontend/src/contexts/__tests__/round.test.tsx
+++ b/frontend/src/contexts/__tests__/round.test.tsx
@@ -1,24 +1,20 @@
-import { renderHook } from "@testing-library/react-hooks";
-import { RoundProvider, useRound } from "../round";
+import { act, renderHook, RenderResult } from "@testing-library/react-hooks";
+import { RoundAction, RoundProvider, useRound } from "../round";
 
 describe("useRound()", () => {
   it("returns rounds context when used inside RoundProvider", () => {
     const { result } = renderHook(() => useRound(), { wrapper: RoundProvider });
 
-    const {
-      roundNumber,
-      setup,
-      numPlayersChosen,
-      punchlinesChosen,
-      hostViewIndex,
-      winner,
-    } = result.current;
+    const [
+      { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+      dispatch,
+    ] = result.current;
     expect(roundNumber).toBe(0);
-    expect(setup).toEqual({ setup: "", type: "PICK_ONE" });
+    expect(setup).toBeUndefined();
     expect(numPlayersChosen).toBe(0);
-    expect(punchlinesChosen).toEqual([]);
-    expect(hostViewIndex).toBe(0);
-    expect(winner).toEqual({ winningPlayerId: "", winningPunchlines: [] });
+    expect(chosenPunchlines).toEqual([]);
+    expect(winner).toBeUndefined();
+    expect(dispatch).toBeDefined();
   });
 
   it("throws error when used outside RoundProvider", () => {
@@ -27,5 +23,442 @@ describe("useRound()", () => {
     expect(result.error).toEqual(
       Error("useRound() must be used within a RoundProvider")
     );
+  });
+
+  describe("dispatch()", () => {
+    const setupRound = (result: RenderResult<ReturnType<typeof useRound>>) => {
+      const [, dispatch] = result.current;
+      act(() => {
+        dispatch({ type: RoundAction.NEW_ROUND, roundNumber: 1 });
+        dispatch({
+          type: RoundAction.SET_SETUP,
+          setup: {
+            setup: "What is the best funny number?",
+            type: "PICK_ONE",
+          },
+        });
+        dispatch({ type: RoundAction.INCREMENT_PLAYERS_CHOSEN });
+        dispatch({ type: RoundAction.INCREMENT_PLAYERS_CHOSEN });
+        dispatch({
+          type: RoundAction.SET_CHOSEN_PUNCHLINES,
+          punchlines: [["420"], ["69"]],
+        });
+        dispatch({
+          type: RoundAction.SET_WINNER,
+          winningPlayerId: "420",
+          winningPunchlines: ["420"],
+        });
+      });
+
+      const [
+        { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+      ] = result.current;
+      expect(roundNumber).toBe(1);
+      expect(setup).toEqual({
+        setup: "What is the best funny number?",
+        type: "PICK_ONE",
+      });
+      expect(numPlayersChosen).toBe(2);
+      expect(chosenPunchlines).toEqual([
+        { text: "420", viewed: false },
+        { text: "69", viewed: false },
+      ]);
+      expect(winner).toEqual({
+        winningPlayerId: "420",
+        winningPunchlines: ["420"],
+      });
+    };
+
+    describe("NEW_ROUND", () => {
+      it("resets existing state and sets roundNumber", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() => dispatch({ type: RoundAction.NEW_ROUND, roundNumber: 2 }));
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(2);
+        expect(setup).toBeUndefined();
+        expect(numPlayersChosen).toBe(0);
+        expect(chosenPunchlines).toEqual([]);
+        expect(winner).toBeUndefined();
+      });
+    });
+
+    describe("SET_SETUP", () => {
+      it("sets the setup for the round", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_SETUP,
+            setup: {
+              setup: "Why did the chicken cross the road?",
+              type: "PICK_ONE",
+            },
+          })
+        );
+
+        const [{ setup }] = result.current;
+        expect(setup).toEqual({
+          setup: "Why did the chicken cross the road?",
+          type: "PICK_ONE",
+        });
+      });
+
+      it("sets the setup for the round without effecting other state", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_SETUP,
+            setup: {
+              setup: "Why did the chicken cross the road?",
+              type: "PICK_ONE",
+            },
+          })
+        );
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(1);
+        expect(setup).toEqual({
+          setup: "Why did the chicken cross the road?",
+          type: "PICK_ONE",
+        });
+        expect(numPlayersChosen).toBe(2);
+        expect(chosenPunchlines).toEqual([
+          { text: "420", viewed: false },
+          { text: "69", viewed: false },
+        ]);
+        expect(winner).toEqual({
+          winningPlayerId: "420",
+          winningPunchlines: ["420"],
+        });
+      });
+    });
+
+    describe("INCREMENT_PLAYERS_CHOSEN", () => {
+      it("increments players chosen", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.INCREMENT_PLAYERS_CHOSEN,
+          })
+        );
+
+        const [{ numPlayersChosen }] = result.current;
+        expect(numPlayersChosen).toBe(1);
+      });
+
+      it("increments players chosen without effecting other state", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.INCREMENT_PLAYERS_CHOSEN,
+          })
+        );
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(1);
+        expect(setup).toEqual({
+          setup: "What is the best funny number?",
+          type: "PICK_ONE",
+        });
+        expect(numPlayersChosen).toBe(3);
+        expect(chosenPunchlines).toEqual([
+          { text: "420", viewed: false },
+          { text: "69", viewed: false },
+        ]);
+        expect(winner).toEqual({
+          winningPlayerId: "420",
+          winningPunchlines: ["420"],
+        });
+      });
+    });
+
+    describe("SET_CHOSEN_PUNCHLINES", () => {
+      it("sets chosen punchlines", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+
+        const [{ chosenPunchlines }] = result.current;
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: false },
+        ]);
+      });
+
+      it("sets chosen punchlines without effecting other state", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(1);
+        expect(setup).toEqual({
+          setup: "What is the best funny number?",
+          type: "PICK_ONE",
+        });
+        expect(numPlayersChosen).toBe(2);
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: false },
+        ]);
+        expect(winner).toEqual({
+          winningPlayerId: "420",
+          winningPunchlines: ["420"],
+        });
+      });
+    });
+
+    describe("MARK_PUNCHLINE_READ", () => {
+      it("marks chosen punchline read", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+        act(() =>
+          dispatch({
+            type: RoundAction.MARK_PUNCHLINE_READ,
+            index: 1,
+          })
+        );
+
+        const [{ chosenPunchlines }] = result.current;
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: true },
+        ]);
+      });
+
+      it("marks chosen punchline read without effecting other state", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.MARK_PUNCHLINE_READ,
+            index: 1,
+          })
+        );
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(1);
+        expect(setup).toEqual({
+          setup: "What is the best funny number?",
+          type: "PICK_ONE",
+        });
+        expect(numPlayersChosen).toBe(2);
+        expect(chosenPunchlines).toEqual([
+          { text: "420", viewed: false },
+          { text: "69", viewed: true },
+        ]);
+        expect(winner).toEqual({
+          winningPlayerId: "420",
+          winningPunchlines: ["420"],
+        });
+      });
+
+      it("does not modify state if index is less than 0", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+        const [initialState] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.MARK_PUNCHLINE_READ,
+            index: -1,
+          })
+        );
+
+        const [state] = result.current;
+        const { chosenPunchlines } = state;
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: false },
+        ]);
+        expect(state).toBe(initialState);
+      });
+
+      it("does not modify state if index is equal to the length of chosenPunchlines", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+        const [initialState] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.MARK_PUNCHLINE_READ,
+            index: 2,
+          })
+        );
+
+        const [state] = result.current;
+        const { chosenPunchlines } = state;
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: false },
+        ]);
+        expect(state).toBe(initialState);
+      });
+
+      it("does not modify state if index exceeds the length of chosenPunchlines", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_CHOSEN_PUNCHLINES,
+            punchlines: [["To get to the other side"], ["To go to KFC"]],
+          })
+        );
+        const [initialState] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.MARK_PUNCHLINE_READ,
+            index: 3,
+          })
+        );
+
+        const [state] = result.current;
+        const { chosenPunchlines } = state;
+        expect(chosenPunchlines).toEqual([
+          { text: "To get to the other side", viewed: false },
+          { text: "To go to KFC", viewed: false },
+        ]);
+        expect(state).toBe(initialState);
+      });
+    });
+
+    describe("SET_WINNER", () => {
+      it("sets the winner", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_WINNER,
+            winningPlayerId: "123",
+            winningPunchlines: ["To go to KFC"],
+          })
+        );
+
+        const [{ winner }] = result.current;
+        expect(winner).toEqual({
+          winningPlayerId: "123",
+          winningPunchlines: ["To go to KFC"],
+        });
+      });
+
+      it("sets the winner without effecting other state", () => {
+        const { result } = renderHook(() => useRound(), {
+          wrapper: RoundProvider,
+        });
+        setupRound(result);
+
+        const [, dispatch] = result.current;
+        act(() =>
+          dispatch({
+            type: RoundAction.SET_WINNER,
+            winningPlayerId: "123",
+            winningPunchlines: ["To go to KFC"],
+          })
+        );
+
+        const [
+          { roundNumber, setup, numPlayersChosen, chosenPunchlines, winner },
+        ] = result.current;
+        expect(roundNumber).toBe(1);
+        expect(setup).toEqual({
+          setup: "What is the best funny number?",
+          type: "PICK_ONE",
+        });
+        expect(numPlayersChosen).toBe(2);
+        expect(chosenPunchlines).toEqual([
+          { text: "420", viewed: false },
+          { text: "69", viewed: false },
+        ]);
+        expect(winner).toEqual({
+          winningPlayerId: "123",
+          winningPunchlines: ["To go to KFC"],
+        });
+      });
+    });
   });
 });

--- a/frontend/src/hooks/socket.ts
+++ b/frontend/src/hooks/socket.ts
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect } from "react";
 import { PlayersActions, usePlayers } from "../contexts/players";
 import { PunchlinesAction, usePunchlines } from "../contexts/punchlines";
-import { useRound } from "../contexts/round";
+import { RoundAction, useRound } from "../contexts/round";
 import { Settings } from "../GameRouter";
 import createPersistedState from "use-persisted-state";
 import { Socket } from "socket.io-client";
 import { MemoryHistory } from "history";
+import { Setup } from "../types";
 import { Player } from "../types";
 
 const usePlayerIdState = createPersistedState("playerId");
@@ -21,13 +22,7 @@ export const useSetupSocketHandlers = (
   const [, setToken] = useTokenState("");
   const [, dispatchPlayers] = usePlayers();
   const [, dispatchPunchlines] = usePunchlines();
-  const {
-    setRoundNumber,
-    setSetup,
-    incrementPlayersChosen,
-    setPunchlinesChosen,
-    setWinner,
-  } = useRound();
+  const [, dispatchRound] = useRound();
 
   // Connection
   const handleNavigate = useCallback(
@@ -112,24 +107,47 @@ export const useSetupSocketHandlers = (
       }),
     [dispatchPunchlines]
   );
-  const handleRoundNumber = useCallback(setRoundNumber, [setRoundNumber]);
-  const handleRoundSetup = useCallback(setSetup, [setSetup]);
-  const handleRoundIncrementPlayersChosen = useCallback(
-    incrementPlayersChosen,
-    [incrementPlayersChosen]
+  const handleRoundNumber = useCallback(
+    (roundNumber: number) =>
+      dispatchRound({
+        type: RoundAction.NEW_ROUND,
+        roundNumber,
+      }),
+    [dispatchRound]
   );
-  const handleRoundChosenPunchlines = useCallback(setPunchlinesChosen, [
-    setPunchlinesChosen,
-  ]);
+  const handleRoundSetup = useCallback(
+    (setup: Setup) =>
+      dispatchRound({
+        type: RoundAction.SET_SETUP,
+        setup,
+      }),
+    [dispatchRound]
+  );
+  const handleRoundIncrementPlayersChosen = useCallback(
+    () => dispatchRound({ type: RoundAction.INCREMENT_PLAYERS_CHOSEN }),
+    [dispatchRound]
+  );
+  const handleRoundChosenPunchlines = useCallback(
+    (punchlines: string[][]) =>
+      dispatchRound({
+        type: RoundAction.SET_CHOSEN_PUNCHLINES,
+        punchlines,
+      }),
+    [dispatchRound]
+  );
   const handleRoundWinner = useCallback(
     (winningPlayerId: string, winningPunchlines: string[]) => {
-      setWinner(winningPlayerId, winningPunchlines);
+      dispatchRound({
+        type: RoundAction.SET_WINNER,
+        winningPlayerId,
+        winningPunchlines,
+      });
       dispatchPlayers({
         type: PlayersActions.INCREMENT_SCORE,
         id: winningPlayerId,
       });
     },
-    [dispatchPlayers, setWinner]
+    [dispatchPlayers, dispatchRound]
   );
 
   useEffect(() => {

--- a/frontend/src/pages/EndRoundPage/index.tsx
+++ b/frontend/src/pages/EndRoundPage/index.tsx
@@ -18,7 +18,7 @@ const EndRoundPage = ({ roundLimit }: { roundLimit: number }) => {
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
 
-  const { roundNumber, setup, winner } = useRound();
+  const [{ roundNumber, setup, winner }] = useRound();
 
   return (
     <div className={styles.container}>
@@ -28,11 +28,11 @@ const EndRoundPage = ({ roundLimit }: { roundLimit: number }) => {
       <div className={styles.endOfRound}>
         <div style={{ margin: `24px 0` }}>
           <h5>The Setup:</h5>
-          <h2>{setup.setup}</h2>
+          <h2>{setup?.setup}</h2>
         </div>
 
         <h5 style={{ marginBottom: `12px` }}>Winning Punchline:</h5>
-        {winner.winningPunchlines.map((punchline) => (
+        {winner?.winningPunchlines.map((punchline) => (
           <PunchlineCard key={punchline} text={punchline} />
         ))}
 

--- a/frontend/src/pages/StartRoundPage/index.tsx
+++ b/frontend/src/pages/StartRoundPage/index.tsx
@@ -13,7 +13,7 @@ const StartRoundPage = ({ roundLimit }: { roundLimit: number }) => {
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
   const [, setResponse] = useState("");
-  const { roundNumber } = useRound();
+  const [{ roundNumber }] = useRound();
   const socket = useSocket();
 
   return (

--- a/frontend/src/pages/StartRoundPage/index.tsx
+++ b/frontend/src/pages/StartRoundPage/index.tsx
@@ -26,7 +26,7 @@ const StartRoundPage = ({ roundLimit }: { roundLimit: number }) => {
           {playerIsHost
             ? "You are The Man™."
             : `${
-                host && players[host] ? players[host] : "No-one"
+                host && players[host] ? players[host].nickname : "No-one"
               } is The Man™.`}
         </p>
       </div>

--- a/frontend/src/pages/SubmitPunchlinePage/index.tsx
+++ b/frontend/src/pages/SubmitPunchlinePage/index.tsx
@@ -7,7 +7,7 @@ import ProgressBar from "../../components/ProgressBar";
 import PunchlineCard from "../../components/PunchlineCard";
 import Button from "../../components/Button";
 import Setup from "../../components/Setup";
-import { useRound } from "../../contexts/round";
+import { RoundAction, useRound } from "../../contexts/round";
 import { usePlayers } from "../../contexts/players";
 import { PunchlinesAction, usePunchlines } from "../../contexts/punchlines";
 import { Punchline } from "../../types";
@@ -21,8 +21,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
 
   const [{ host, count }] = usePlayers();
   const [punchlines, dispatchPunchlines] = usePunchlines();
-  const { roundNumber, setup, numPlayersChosen, incrementPlayersChosen } =
-    useRound();
+  const [{ roundNumber, setup, numPlayersChosen }, dispatchRound] = useRound();
 
   const [playerId] = usePlayerIdState("");
   const playerIsHost = playerId === host;
@@ -51,7 +50,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
       setPunchlineSubmitted(punchlineSelected);
       setPunchlineSelected(undefined);
 
-      incrementPlayersChosen();
+      dispatchRound({ type: RoundAction.INCREMENT_PLAYERS_CHOSEN });
       socket.emit(
         "round:player-choose",
         [punchlineSelected.text],
@@ -60,7 +59,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
         }
       );
     }
-  }, [dispatchPunchlines, incrementPlayersChosen, punchlineSelected, socket]);
+  }, [dispatchPunchlines, dispatchRound, punchlineSelected, socket]);
 
   return (
     <>
@@ -74,7 +73,7 @@ const SubmitPunchlinePage = ({ roundLimit }: { roundLimit: number }) => {
         header="Scoreboard"
       />
       <div className={styles.container}>
-        <Setup setupText={setup.setup} />
+        <Setup setupText={setup?.setup ?? ""} />
 
         <ProgressBar
           playersChosen={numPlayersChosen}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,3 +9,13 @@ export type Punchline = {
   new?: boolean;
   viewed?: boolean;
 };
+
+export type Setup = {
+  setup: string;
+  type: "PICK_ONE" | "PICK_TWO" | "DRAW_TWO_PICK_THREE";
+};
+
+export type Winner = {
+  winningPlayerId: string;
+  winningPunchlines: string[];
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,6 @@ export type Setup = {
 };
 
 export type Winner = {
-  winningPlayerId: string;
+  winningPlayerId: Player["id"];
   winningPunchlines: string[];
 };


### PR DESCRIPTION
This a child issue of #131. See the parent issue for greater context (pun intended) on the rationale for this change.

### Summary of changes

- Converts `RoundProvider` to `useReducer()` internally.
  - The reducer includes five actions: `NEW_ROUND`, `SET_SETUP`, `INCREMENT_PLAYERS_CHOSEN`, `SET_CHOSEN_PUNCHLINES`, `MARK_PUNCHLINE_READ`, and `SET_WINNER`.
  - This removes the following callbacks:
    - `setRoundNumber()` is replaced by the `NEW_ROUND` action.
    - `setSetup()` is replaced by the `SET_SETUP` action.
    - `incrementPlayersChosen()` is replaced by the `INCREMENT_PLAYERS_CHOSEN` action.
    - `setPunchlinesChosen()` is replaced by the `SET_CHOSEN_PUNCHLINES` action.
    - `markPunchlineRead()` is replaced by the `MARK_PUNCHLINE_READ` action.
    - `setHostViewIndex()` was not used within the code and was only removed.
    - `setWinner()`was replaced by the `SET_WINNER` action.
  - `RoundProvider` now returns a tuple consisting of the state object and dispatch function.
    - The state object contains keys for `roundNumber`, `setup`, `numPlayersChosen`, `chosenPunchlines`, and `winner`.
      - `roundNumber` is the number for the current round and is set by `NEW_ROUND`.
      - `setup` is the setup card (i.e. "Why did the chicken cross the road?") for the current round and is set by `SET_SETUP`.
      - `numPlayersChosen` is the number of players that have chosen a punchline for the current round. Each time a player choses a punchline it is incremented by `INCREMENT_PLAYERS_CHOSEN`.
      - `chosenPunchlines` is an array of `Punchline`'s chosen by all players.
      - `winner` is the winner of the round consisting of `winningPlayerId` for the winning players ID and `winningPunchlines` consisting of an array of strings for their winning punchlines (an array to support #81 in the future).
  - Improves testing to include 100% coverage for `src/contexts/round.tsx`

### Notes

- Some of the actions used in the reducer (i.e. `NEW_ROUND` and `SET_SETUP`) could potentially be combined where they always occur together. This has not been implemented in this PR as it would require backend changes which is considered outside of scope.
- Closes #131.