### PR TITLE
Connect socket within GameRouter

### DIFF
--- a/frontend/src/pages/NicknamePage/index.tsx
+++ b/frontend/src/pages/NicknamePage/index.tsx
@@ -1,17 +1,9 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useState } from "react";
 import createPersistedState from "use-persisted-state";
 import InputField from "../../components/InputField";
 import Button from "../../components/Button";
 import styles from "./style.module.css";
-import { BrowserHistoryContext } from "../../App";
-import { getRequestErrorMessage, useGet, usePost } from "../../hooks/axios";
-import { useSocket } from "../../contexts/socket";
+import { getRequestErrorMessage, usePost } from "../../hooks/axios";
 
 const usePlayerIdState = createPersistedState("playerId");
 const useTokenState = createPersistedState("token");
@@ -22,60 +14,13 @@ type Props = {
 
 const NicknamePage = ({ gameCode }: Props) => {
   const [nickname, setNickname] = useState("");
-  const [playerId, setPlayerId] = usePlayerIdState("");
-  const [token, setToken] = useTokenState("");
-  const browserHistory = useContext(BrowserHistoryContext);
-  const socket = useSocket();
-
-  const [, validateGameCode] = useGet(
-    "/api/game/validate",
-    /*
-    As `validateGameCode` runs inside a `useEffect()` we need to create the
-    config object with `useMemo()` to prevent unnecessary re-renders.
-     */
-    useMemo(
-      () => ({
-        params: { gameCode },
-      }),
-      [gameCode]
-    )
-  );
+  const [, setPlayerId] = usePlayerIdState("");
+  const [, setToken] = useTokenState("");
 
   const [{ error: createPlayerError }, createPlayer] = usePost<{
     playerId: string;
     token: string;
   }>("/api/player/create", undefined, { params: { gameCode, nickname } });
-
-  useEffect(() => {
-    const controller = new AbortController();
-    (async () => {
-      const response = await validateGameCode(controller);
-      if (response === null) {
-        browserHistory.push("/");
-      }
-    })();
-    return () => controller.abort();
-  }, [browserHistory, validateGameCode]);
-
-  const tryConnect = useCallback(async () => {
-    if (playerId && token) {
-      socket.auth = { gameCode, playerId, token };
-      // If the connection fails here, playerId and token are cleared by event handler in GameRouter
-      // This reruns this useEffect since playerId and token changed,
-      // but it does not connect again because playerId and token are falsy
-      socket.connect();
-    }
-  }, [gameCode, playerId, socket, token]);
-
-  useEffect(() => {
-    let mounted = true;
-    if (mounted) {
-      tryConnect();
-    }
-    return () => {
-      mounted = false;
-    };
-  }, [gameCode, token, tryConnect]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
This change moves the socket connection logic from `NicknamePage` to a more suitable location in `GameRouter`.

This is a pure refactor and does not change any current functionality. However, this change will help facilitate fixing #121 and implementing #101 in the future, as players will be able to bypass the `NicknamePage` if they refresh their page and return to the game.

Closes #136