### PR TITLE
Add Socket types

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm set-script prepare ""
 
       - name: Install Node.js dependencies
-        run: npm ci -w=frontend
+        run: npm ci -w=frontend -w=backend
 
       - name: Run linter
         run: npm run lint -w=frontend

--- a/backend/src/handlers/__tests__/game.handler.test.ts
+++ b/backend/src/handlers/__tests__/game.handler.test.ts
@@ -29,7 +29,7 @@ describe("Game handler", () => {
     startGame: (callback: (data: string) => void) => Promise<void>;
     updateSetting: (
       setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-      value: number | undefined,
+      value: number,
       callback: (data: string) => void
     ) => Promise<void>;
   };

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -1,8 +1,8 @@
-import { Socket } from "socket.io";
 import { authenticatePlayer } from "../services/player.service";
+import { SocketType } from "../types/socket";
 
 export default async (
-  socket: Socket,
+  socket: SocketType,
   next: (err?: Error) => void
 ): Promise<void> => {
   const { gameCode, playerId, token } = socket.handshake.auth;

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -19,7 +19,7 @@ export default (
   startGame: (callback: (data: string) => void) => Promise<void>;
   updateSetting: (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined,
+    value: number,
     callback: (data: string) => void
   ) => Promise<void>;
 } => {
@@ -49,7 +49,7 @@ export default (
 
   const updateSetting = async (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined,
+    value: number,
     callback: (data: string) => void
   ): Promise<void> => {
     try {

--- a/backend/src/handlers/game.handler.ts
+++ b/backend/src/handlers/game.handler.ts
@@ -1,5 +1,4 @@
 import { Game, GameState, Player } from "../models";
-import { Server, Socket } from "socket.io";
 import {
   getGame,
   initialiseNextRound as initialiseNextRoundService,
@@ -11,10 +10,11 @@ import {
 import { ServiceError } from "../util";
 import { RoundState } from "../models/round.model";
 import { MinPlayers } from "../models/settings.model";
+import { ServerType, SocketData, SocketType } from "../types/socket";
 
 export default (
-  io: Server,
-  socket: Socket
+  io: ServerType,
+  socket: SocketType
 ): {
   startGame: (callback: (data: string) => void) => Promise<void>;
   updateSetting: (
@@ -23,7 +23,7 @@ export default (
     callback: (data: string) => void
   ) => Promise<void>;
 } => {
-  const { gameCode, playerId } = socket.data;
+  const { gameCode, playerId } = socket.data as SocketData;
 
   const startGame = async (callback: (data: string) => void): Promise<void> => {
     try {
@@ -84,7 +84,7 @@ export default (
 };
 
 export const initialiseNextRound = async (
-  io: Server,
+  io: ServerType,
   gameCode: Game["gameCode"],
   hostId: Player["id"]
 ): Promise<void> => {
@@ -98,7 +98,7 @@ export const initialiseNextRound = async (
   io.to(gameCode).emit("navigate", RoundState.before);
 };
 
-export const emitNavigate = (socket: Socket, game: Game): void => {
+export const emitNavigate = (socket: SocketType, game: Game): void => {
   switch (game.state) {
     case GameState.lobby:
       socket.emit("navigate", GameState.lobby);
@@ -106,34 +106,41 @@ export const emitNavigate = (socket: Socket, game: Game): void => {
   }
 };
 
-export const emitHost = async (io: Server, socket: Socket): Promise<void> => {
-  const host = await getHost(io, socket.data.gameCode);
+export const emitHost = async (
+  io: ServerType,
+  socket: SocketType
+): Promise<void> => {
+  const { gameCode } = socket.data as SocketData;
+  const host = await getHost(io, gameCode);
   socket.emit("host", host);
 };
 
 export const getHost = async (
-  io: Server,
+  io: ServerType,
   gameCode: Game["gameCode"]
 ): Promise<Player["id"] | undefined> => {
   const sockets = await io.in(`${gameCode}:host`).fetchSockets();
   return sockets[0]?.data.playerId;
 };
 
-export const setHost = (io: Server, socket: Socket): void => {
-  const { gameCode } = socket.data;
+export const setHost = (io: ServerType, socket: SocketType): void => {
+  const { gameCode, playerId } = socket.data as SocketData;
   socket.join(`${gameCode}:host`);
-  io.to(gameCode).emit("host", socket.data.playerId);
+  io.to(gameCode).emit("host", playerId);
 };
 
-export const isHost = (socket: Socket, gameCode: Game["gameCode"]): boolean => {
+export const isHost = (
+  socket: SocketType,
+  gameCode: Game["gameCode"]
+): boolean => {
   return socket.rooms.has(`${gameCode}:host`);
 };
 
 export const assignNextHost = async (
-  io: Server,
-  socket: Socket
+  io: ServerType,
+  socket: SocketType
 ): Promise<Player["id"]> => {
-  const { gameCode, playerId } = socket.data;
+  const { gameCode, playerId } = socket.data as SocketData;
   if (isHost(socket, gameCode)) {
     const { activePlayers, socketsByPlayerId } = await getActivePlayers(
       io,
@@ -157,18 +164,18 @@ export const assignNextHost = async (
 };
 
 export const getActivePlayers = async (
-  io: Server,
+  io: ServerType,
   gameCode: Game["gameCode"]
 ): Promise<{
   activePlayers: Player[];
   game: Game;
-  socketsByPlayerId: Map<Player["id"], Socket>;
+  socketsByPlayerId: Map<Player["id"], SocketType>;
 }> => {
   const sockets = await getSockets(io, gameCode);
 
   const game = await getGame(gameCode);
 
-  const socketByPlayerId = new Map<Player["id"], Socket>(
+  const socketByPlayerId = new Map<Player["id"], SocketType>(
     sockets.map((socket) => [socket.data.playerId, socket])
   );
   return {
@@ -181,8 +188,8 @@ export const getActivePlayers = async (
 };
 
 export const getSockets = async (
-  io: Server,
+  io: ServerType,
   gameCode: Game["gameCode"]
-): Promise<Socket[]> => {
-  return (await io.in(gameCode).fetchSockets()) as unknown as Socket[];
+): Promise<SocketType[]> => {
+  return (await io.in(gameCode).fetchSockets()) as unknown as SocketType[];
 };

--- a/backend/src/handlers/player.handler.ts
+++ b/backend/src/handlers/player.handler.ts
@@ -3,7 +3,6 @@ import {
   initialisePlayer,
   removePlayer,
 } from "../services/player.service";
-import { Server, Socket } from "socket.io";
 import { GameState } from "../models";
 import {
   assignNextHost,
@@ -14,15 +13,16 @@ import {
 } from "./game.handler";
 import { getGame } from "../services/game.service";
 import { MinPlayers } from "../models/settings.model";
+import { ServerType, SocketData, SocketType } from "../types/socket";
 
 export default (
-  io: Server,
-  socket: Socket
+  io: ServerType,
+  socket: SocketType
 ): {
   playerLeave: () => Promise<void>;
   playerLeaving: () => void;
 } => {
-  const { gameCode, playerId } = socket.data;
+  const { gameCode, playerId } = socket.data as SocketData;
 
   const playerLeaving = async (): Promise<void> => {
     try {
@@ -69,9 +69,12 @@ export default (
   };
 };
 
-export const playerJoin = async (io: Server, socket: Socket): Promise<void> => {
+export const playerJoin = async (
+  io: ServerType,
+  socket: SocketType
+): Promise<void> => {
   try {
-    const { gameCode, playerId } = socket.data;
+    const { gameCode, playerId } = socket.data as SocketData;
 
     const game = await getGame(gameCode);
 

--- a/backend/src/handlers/round.handler.ts
+++ b/backend/src/handlers/round.handler.ts
@@ -1,4 +1,3 @@
-import { Server, Socket } from "socket.io";
 import {
   enterHostChoosesState,
   playerChoosePunchlines as playerChoosePunchlinesService,
@@ -18,10 +17,11 @@ import {
   checkGameEnded,
 } from "../services/game.service";
 import { GameState, SetupType } from "../models";
+import { ServerType, SocketData, SocketType } from "../types/socket";
 
 export default (
-  io: Server,
-  socket: Socket
+  io: ServerType,
+  socket: SocketType
 ): {
   hostStartRound: (callback: (data: string) => void) => void;
   playerChoosePunchlines: (
@@ -35,7 +35,7 @@ export default (
   ) => Promise<void>;
   hostNextRound: (callback: (data: string) => void) => void;
 } => {
-  const { gameCode, playerId } = socket.data;
+  const { gameCode, playerId } = socket.data as SocketData;
 
   const hostStartRound = async (callback: (data: string) => void) => {
     try {
@@ -88,15 +88,14 @@ export default (
       );
 
       socket.to(gameCode).emit("round:increment-players-chosen");
-
       const sockets = (await io
         .in(gameCode)
-        .fetchSockets()) as unknown as Socket[];
+        .fetchSockets()) as unknown as SocketType[];
 
       if (
         sockets
           .filter((socket) => !socket.rooms.has(`${gameCode}:host`))
-          .every((socket) => chosenPlayers.has(socket.data.playerId))
+          .every((socket) => chosenPlayers.has(socket.data.playerId as string))
       ) {
         const chosenPunchlines = await enterHostChoosesState(gameCode);
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,12 @@ import config from "./config";
 import { Connection, Auth } from "./handlers";
 import routes from "./routes";
 import mongoose from "mongoose";
+import {
+  ClientToServerEvents,
+  InterServerEvents,
+  ServerToClientEvents,
+  SocketData,
+} from "./types/socket";
 
 // Init DB
 // Connect to local running instance of mongodb, on telosdatabase db
@@ -45,7 +51,12 @@ server.listen(config.port, () => {
 });
 
 // Setup Socket.IO
-const io = new IOServer(server, {
+const io = new IOServer<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+>(server, {
   cors: {
     origin: config.origin,
   },

--- a/backend/src/models/settings.model.ts
+++ b/backend/src/models/settings.model.ts
@@ -4,8 +4,8 @@ export const MaxPlayers = 40;
 export const MinPlayers = 3;
 
 export interface Settings extends Document {
-  roundLimit?: number;
-  maxPlayers?: number;
+  roundLimit: number;
+  maxPlayers: number;
 }
 
 export const SettingsSchema: Schema = new Schema({

--- a/backend/src/types/socket.ts
+++ b/backend/src/types/socket.ts
@@ -1,0 +1,80 @@
+import { Game, GameState, Player, Setup } from "../models";
+import { Server, Socket } from "socket.io";
+import { RoundState } from "../models/round.model";
+
+export interface ServerToClientEvents {
+  navigate: (state: GameState | RoundState) => void;
+  host: (host: string) => void;
+  "settings:initial": (settings: {
+    roundLimit: number | undefined;
+    maxPlayers: number | undefined;
+  }) => void;
+  "settings:update": (
+    setting: "MAX_PLAYERS" | "ROUND_LIMIT",
+    value: number | undefined
+  ) => void;
+
+  "players:initial": (
+    players: { id: string; nickname: Player["nickname"]; score: number }[]
+  ) => void;
+  "players:add": (playerId: string, nickname: Player["nickname"]) => void;
+  "players:remove": (playerId: string) => void;
+
+  "round:number": (roundNumber: number) => void;
+  "round:setup": (setup: Setup) => void;
+  "round:increment-players-chosen": () => void;
+  "round:chosen-punchlines": (chosenPunchlines: string[][]) => void;
+  "round:host-view": (index: number) => void;
+  "round:winner": (
+    winningPlayerId: string,
+    winningPunchlines: string[]
+  ) => void;
+
+  "punchlines:add": (addedPunchlines: string[]) => void;
+  "punchlines:remove": (removedPunchlines: string[]) => void;
+}
+
+export interface ClientToServerEvents {
+  start: (callback: (data: string) => void) => void;
+  "settings:update": (
+    setting: "MAX_PLAYERS" | "ROUND_LIMIT",
+    value: number | undefined,
+    callback: (data: string) => void
+  ) => void;
+
+  "round:host-begin": (callback: (data: string) => void) => void;
+  "round:player-choose": (
+    punchlines: string[],
+    callback: (data: string) => void
+  ) => void;
+  "round:host-view": (index: number, callback: (data: string) => void) => void;
+  "round:host-choose": (
+    winningPunchlines: string[],
+    callback: (data: string) => void
+  ) => void;
+  "round:host-next": (callback: (data: string) => void) => void;
+}
+
+export interface InterServerEvents {
+  [event: string]: never;
+}
+
+export interface SocketData {
+  gameCode: Game["gameCode"];
+  playerId: string;
+  nickname: Player["nickname"];
+}
+
+export type ServerType = Server<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+>;
+
+export type SocketType = Socket<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+>;

--- a/backend/src/types/socket.ts
+++ b/backend/src/types/socket.ts
@@ -6,12 +6,12 @@ export interface ServerToClientEvents {
   navigate: (state: GameState | RoundState) => void;
   host: (host: string) => void;
   "settings:initial": (settings: {
-    roundLimit: number | undefined;
-    maxPlayers: number | undefined;
+    roundLimit: number;
+    maxPlayers: number;
   }) => void;
   "settings:update": (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined
+    value: number
   ) => void;
 
   "players:initial": (
@@ -38,7 +38,7 @@ export interface ClientToServerEvents {
   start: (callback: (data: string) => void) => void;
   "settings:update": (
     setting: "MAX_PLAYERS" | "ROUND_LIMIT",
-    value: number | undefined,
+    value: number,
     callback: (data: string) => void
   ) => void;
 

--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -13,11 +13,12 @@ import {
 import { SocketProvider } from "./contexts/socket";
 import io from "socket.io-client";
 import { useSetupSocketHandlers } from "./hooks/socket";
+import { SocketType } from "./types/socket";
 import createPersistedState from "use-persisted-state";
 import { BrowserHistoryContext } from "./App";
 import { useGet } from "./hooks/axios";
 
-const socket = io({
+const socket: SocketType = io({
   autoConnect: false,
 });
 
@@ -103,7 +104,7 @@ const GameRouter = () => {
           </Route>
 
           <Route path="/before">
-            <StartRoundPage roundLimit={settings.roundLimit} />
+            <StartRoundPage roundLimit={settings.roundLimit ?? 0} />
           </Route>
 
           <Route path="/players_choose">

--- a/frontend/src/GameRouter.tsx
+++ b/frontend/src/GameRouter.tsx
@@ -104,7 +104,7 @@ const GameRouter = () => {
           </Route>
 
           <Route path="/before">
-            <StartRoundPage roundLimit={settings.roundLimit ?? 0} />
+            <StartRoundPage roundLimit={settings.roundLimit} />
           </Route>
 
           <Route path="/players_choose">

--- a/frontend/src/contexts/socket.tsx
+++ b/frontend/src/contexts/socket.tsx
@@ -1,10 +1,10 @@
 import React, { PropsWithChildren, useContext } from "react";
-import { Socket } from "socket.io-client";
+import { SocketType } from "../types/socket";
 
-const SocketContext = React.createContext<Socket | undefined>(undefined);
+const SocketContext = React.createContext<SocketType | undefined>(undefined);
 
 interface SocketProviderProps {
-  socket: Socket;
+  socket: SocketType;
 }
 
 export const SocketProvider = ({
@@ -16,7 +16,7 @@ export const SocketProvider = ({
   );
 };
 
-export const useSocket = (): Socket => {
+export const useSocket = (): SocketType => {
   const socket = useContext(SocketContext);
 
   if (socket === undefined) {

--- a/frontend/src/hooks/socket.ts
+++ b/frontend/src/hooks/socket.ts
@@ -4,15 +4,15 @@ import { PunchlinesAction, usePunchlines } from "../contexts/punchlines";
 import { useRound } from "../contexts/round";
 import { Settings } from "../GameRouter";
 import createPersistedState from "use-persisted-state";
-import { Socket } from "socket.io-client";
 import { MemoryHistory } from "history";
 import { Player } from "../types";
+import { SocketType } from "../types/socket";
 
 const usePlayerIdState = createPersistedState("playerId");
 const useTokenState = createPersistedState("token");
 
 export const useSetupSocketHandlers = (
-  socket: Socket,
+  socket: SocketType,
   memoryHistory: MemoryHistory,
   settings: Settings,
   setSettings: React.Dispatch<React.SetStateAction<Settings>>
@@ -50,7 +50,10 @@ export const useSetupSocketHandlers = (
       }),
     [dispatchPlayers]
   );
-  const handleSettingsInitial = useCallback(setSettings, [setSettings]);
+  const handleSettingsInitial = useCallback(
+    (settings: Settings) => setSettings(settings),
+    [setSettings]
+  );
   const handleConnectError = useCallback(() => {
     setPlayerId("");
     setToken("");

--- a/frontend/src/pages/LobbyPage/index.tsx
+++ b/frontend/src/pages/LobbyPage/index.tsx
@@ -44,8 +44,8 @@ const LobbyPage = ({ gameCode, settings }: Props) => {
   // Wait until 500ms after last input before emitting setting update
   const msDebounceDelay = 500;
   const updateSettings = useCallback(
-    (setting: string, value: string) => {
-      debounce((setting: string, value: string) => {
+    (setting: "MAX_PLAYERS" | "ROUND_LIMIT", value: string) => {
+      debounce((setting: "MAX_PLAYERS" | "ROUND_LIMIT", value: string) => {
         if (value.match(/^\d+$/)) {
           socket.emit(
             "settings:update",

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -1,0 +1,7 @@
+import { Socket } from "socket.io-client";
+import {
+  ServerToClientEvents,
+  ClientToServerEvents,
+} from "@nos/backend/src/types/socket";
+
+export type SocketType = Socket<ServerToClientEvents, ClientToServerEvents>;


### PR DESCRIPTION
For some reason we never initially typed the socket events. I have remedied this per the [Socket.io docs](https://socket.io/docs/v4/typescript/).

This defines event handler types in the backend under `src/types/socket.ts`. The handlers in the backend are updated to use these types which ensures that event names and arguments strictly match the defined type. This applies to both the events the backend listens to and those it emits.

Similarly, the frontend defined event handler types under `src/types/socket.ts`, however these derive from the types defined in the backend. This is achieved through [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces#adding-dependencies-to-a-workspace) allowing us to import the backend types via `@nos/backend/src/types/socket`. This works fine for now, but I think longterm it could be a good move to introduce a third package within the monorepo for types, which both frontend & backend depend on as I have had to modify the frontend CI to also install the backend packages. A third package for types would be ideal as it would be very lightweight (ideally no dependencies) to minimise additional CI runtime.

This does not change any functionality, however greatly facilitates the ease of future changes by adding strict type safety.